### PR TITLE
fix: thread safety, resource leaks, and logic errors

### DIFF
--- a/ShichiZip/Bridge/SZArchive.mm
+++ b/ShichiZip/Bridge/SZArchive.mm
@@ -2402,6 +2402,8 @@ static UString SZCompressionMethodSpec(SZCompressionSettings* settings) {
         return UString(L"Deflate64");
     case SZCompressionMethodCopy:
         return UString(L"Copy");
+    default:
+        return UString();
     }
 }
 

--- a/ShichiZip/Bridge/SZCallbacks.mm
+++ b/ShichiZip/Bridge/SZCallbacks.mm
@@ -57,19 +57,17 @@ static NSString* SZFormatFileTime(const FILETIME* ft) {
     if (!ft)
         return nil;
     // FILETIME is 100-nanosecond intervals since 1601-01-01.
-    // NSDate reference is 2001-01-01. Difference is 12622780800 seconds.
+    // dateWithTimeIntervalSince1970 uses Unix epoch (1970-01-01).
+    // Difference between 1601-01-01 and 1970-01-01 is 11644473600 seconds.
     const int64_t ticks = ((int64_t)ft->dwHighDateTime << 32) | ft->dwLowDateTime;
     if (ticks <= 0)
         return nil;
     const NSTimeInterval seconds = (NSTimeInterval)ticks / 10000000.0 - 11644473600.0;
     NSDate* date = [NSDate dateWithTimeIntervalSince1970:seconds];
-    static NSDateFormatter* formatter;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        formatter = [[NSDateFormatter alloc] init];
-        formatter.dateStyle = NSDateFormatterMediumStyle;
-        formatter.timeStyle = NSDateFormatterMediumStyle;
-    });
+    // NSDateFormatter is not thread-safe for formatting; create per-call.
+    NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+    formatter.dateStyle = NSDateFormatterMediumStyle;
+    formatter.timeStyle = NSDateFormatterMediumStyle;
     return [formatter stringFromDate:date];
 }
 

--- a/ShichiZip/Dialogs/CompressDialogController.swift
+++ b/ShichiZip/Dialogs/CompressDialogController.swift
@@ -1942,14 +1942,14 @@ final class CompressDialogController: NSObject, NSTextFieldDelegate, NSComboBoxD
                 sfxSupportDescription = "Windows SFX is only available for 7z archives using Copy, LZMA, LZMA2, or PPMd, and requires the bundled 7z.sfx module."
             #endif
             throw NSError(domain: NSCocoaErrorDomain,
-                          code: NSUserCancelledError,
+                          code: NSFormattingError,
                           userInfo: [NSLocalizedDescriptionKey: sfxSupportDescription])
         }
 
         let trimmedSplitVolumes = splitVolumes.trimmingCharacters(in: .whitespacesAndNewlines)
         if effectiveCreateSFX && !trimmedSplitVolumes.isEmpty {
             throw NSError(domain: NSCocoaErrorDomain,
-                          code: NSUserCancelledError,
+                          code: NSFormattingError,
                           userInfo: [NSLocalizedDescriptionKey: "Windows SFX archives cannot be split into volumes."])
         }
 
@@ -2006,7 +2006,7 @@ final class CompressDialogController: NSObject, NSTextFieldDelegate, NSComboBoxD
            compressionMemory > memoryUsageLimit
         {
             throw NSError(domain: NSCocoaErrorDomain,
-                          code: NSUserCancelledError,
+                          code: NSFormattingError,
                           userInfo: [NSLocalizedDescriptionKey: "Compression requires \(Self.memoryUsageText(for: compressionMemory)), which exceeds the selected memory usage limit of \(Self.memoryUsageText(for: memoryUsageLimit))."])
         }
 
@@ -2024,20 +2024,20 @@ final class CompressDialogController: NSObject, NSTextFieldDelegate, NSComboBoxD
 
         guard password == confirmation else {
             throw NSError(domain: NSCocoaErrorDomain,
-                          code: NSUserCancelledError,
+                          code: NSFormattingError,
                           userInfo: [NSLocalizedDescriptionKey: "Passwords do not match."])
         }
 
         if format.codecName == "zip" {
             guard password.canBeConverted(to: .ascii) else {
                 throw NSError(domain: NSCocoaErrorDomain,
-                              code: NSUserCancelledError,
+                              code: NSFormattingError,
                               userInfo: [NSLocalizedDescriptionKey: "ZIP passwords must use ASCII characters."])
             }
 
             if encryption == .AES256, password.utf8.count > 99 {
                 throw NSError(domain: NSCocoaErrorDomain,
-                              code: NSUserCancelledError,
+                              code: NSFormattingError,
                               userInfo: [NSLocalizedDescriptionKey: "ZIP AES passwords must be 99 bytes or fewer."])
             }
         }
@@ -2053,7 +2053,7 @@ final class CompressDialogController: NSObject, NSTextFieldDelegate, NSComboBoxD
 
         guard let value = UInt32(trimmed), value > 0 else {
             throw NSError(domain: NSCocoaErrorDomain,
-                          code: NSUserCancelledError,
+                          code: NSFormattingError,
                           userInfo: [NSLocalizedDescriptionKey: "Thread count must be a positive number or Auto."])
         }
 
@@ -2079,7 +2079,7 @@ final class CompressDialogController: NSObject, NSTextFieldDelegate, NSComboBoxD
         let standardizedURL = archiveURL.standardizedFileURL
         guard !standardizedURL.lastPathComponent.isEmpty else {
             throw NSError(domain: NSCocoaErrorDomain,
-                          code: NSUserCancelledError,
+                          code: NSFormattingError,
                           userInfo: [NSLocalizedDescriptionKey: "Enter an archive path."])
         }
 
@@ -2089,7 +2089,7 @@ final class CompressDialogController: NSObject, NSTextFieldDelegate, NSComboBoxD
               isDirectory.boolValue
         else {
             throw NSError(domain: NSCocoaErrorDomain,
-                          code: NSUserCancelledError,
+                          code: NSFormattingError,
                           userInfo: [NSLocalizedDescriptionKey: "The destination folder does not exist."])
         }
 
@@ -2097,7 +2097,7 @@ final class CompressDialogController: NSObject, NSTextFieldDelegate, NSComboBoxD
            isDirectory.boolValue
         {
             throw NSError(domain: NSCocoaErrorDomain,
-                          code: NSUserCancelledError,
+                          code: NSFormattingError,
                           userInfo: [NSLocalizedDescriptionKey: "The archive path points to an existing folder."])
         }
 

--- a/ShichiZip/Dialogs/ExtractDialogController.swift
+++ b/ShichiZip/Dialogs/ExtractDialogController.swift
@@ -405,8 +405,15 @@ final class ExtractDialogController: NSObject {
             splitName = splitNameField.stringValue
             enteredPassword = visiblePasswordValue()
             showPassword = showPasswordCheckbox.state == .on
-            selectedPathMode = pathModeOptions[pathModePopup.indexOfSelectedItem].value
-            selectedOverwriteMode = overwriteModeOptions[overwriteModePopup.indexOfSelectedItem].value
+            let pathModeIndex = pathModePopup.indexOfSelectedItem
+            let overwriteModeIndex = overwriteModePopup.indexOfSelectedItem
+            guard pathModeIndex >= 0, pathModeIndex < pathModeOptions.count,
+                  overwriteModeIndex >= 0, overwriteModeIndex < overwriteModeOptions.count
+            else {
+                return nil
+            }
+            selectedPathMode = pathModeOptions[pathModeIndex].value
+            selectedOverwriteMode = overwriteModeOptions[overwriteModeIndex].value
             preserveNtSecurityInfo = ntSecurityCheckbox.state == .on
             eliminateDuplicates = eliminateDuplicatesCheckbox.state == .on
             moveArchiveToTrashAfterExtraction = moveArchiveToTrashCheckbox.state == .on

--- a/ShichiZip/Dialogs/ProgressDialogController.swift
+++ b/ShichiZip/Dialogs/ProgressDialogController.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import os.lock
 
 /// Progress dialog shown during extraction/compression operations
 class ProgressDialogController: NSWindowController, SZProgressDelegate {
@@ -11,12 +12,16 @@ class ProgressDialogController: NSWindowController, SZProgressDelegate {
     private var operationLabel: NSTextField!
     private var cancelButton: NSButton!
 
-    private var cancelled = false
-    private var startTime: Date?
+    private struct ProgressState: Sendable {
+        var cancelled = false
+        var isWaitingForProgress = false
+        var startTime: Date?
+        var lastMetricsUpdateTime: TimeInterval = 0
+    }
+
+    private let stateLock = OSAllocatedUnfairLock(initialState: ProgressState())
     private var speedLabel: NSTextField!
     private var elapsedLabel: NSTextField!
-    private var isWaitingForProgress = false
-    private var lastMetricsUpdateTime: TimeInterval = 0
     var showRequestHandler: (() -> Void)?
 
     var operationTitle: String = "Working..." {
@@ -119,12 +124,15 @@ class ProgressDialogController: NSWindowController, SZProgressDelegate {
     }
 
     func beginWaitingMode(fileName: String? = nil) {
-        let applyWaitingMode = { [weak self] in
+        stateLock.withLock { state in
+            state.isWaitingForProgress = true
+            state.startTime = nil
+            state.lastMetricsUpdateTime = 0
+            state.cancelled = false
+        }
+
+        let applyUI = { [weak self] in
             guard let self else { return }
-            self.isWaitingForProgress = true
-            self.startTime = nil
-            self.lastMetricsUpdateTime = 0
-            self.cancelled = false
             self.cancelButton.isEnabled = true
             self.cancelButton.title = "Cancel"
             self.progressBar.stopAnimation(nil)
@@ -139,18 +147,23 @@ class ProgressDialogController: NSWindowController, SZProgressDelegate {
         }
 
         if Thread.isMainThread {
-            applyWaitingMode()
+            applyUI()
         } else {
-            DispatchQueue.main.async(execute: applyWaitingMode)
+            DispatchQueue.main.async(execute: applyUI)
         }
     }
 
-    private func ensureDeterminateProgress() {
-        guard progressBar.isIndeterminate || isWaitingForProgress else { return }
+    private func ensureDeterminateProgressOnMain() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let needsReset = stateLock.withLock { state -> Bool in
+            guard state.isWaitingForProgress else { return false }
+            state.isWaitingForProgress = false
+            return true
+        }
+        guard needsReset || progressBar.isIndeterminate else { return }
         progressBar.stopAnimation(nil)
         progressBar.isIndeterminate = false
         progressBar.doubleValue = 0
-        isWaitingForProgress = false
     }
 
     func showNowIfNeeded() {
@@ -187,7 +200,7 @@ class ProgressDialogController: NSWindowController, SZProgressDelegate {
     }
 
     @objc private func cancelClicked(_: Any?) {
-        cancelled = true
+        stateLock.withLock { $0.cancelled = true }
         cancelButton.isEnabled = false
         cancelButton.title = "Cancelling..."
     }
@@ -195,50 +208,59 @@ class ProgressDialogController: NSWindowController, SZProgressDelegate {
     // MARK: - SZProgressDelegate (matches ProgressDialog2.cpp)
 
     @objc func progressDidUpdate(_ fraction: Double) {
-        ensureDeterminateProgress()
-        progressBar.doubleValue = fraction
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.ensureDeterminateProgressOnMain()
+            self.progressBar.doubleValue = fraction
+        }
     }
 
     @objc func progressDidUpdateFileName(_ fileName: String) {
-        fileNameLabel.stringValue = fileName
+        DispatchQueue.main.async { [weak self] in
+            self?.fileNameLabel.stringValue = fileName
+        }
     }
 
     @objc func progressDidUpdateBytesCompleted(_ completed: UInt64, total: UInt64) {
-        if total > 0 {
-            ensureDeterminateProgress()
-            progressBar.doubleValue = Double(completed) / Double(total)
+        let metrics: (startTime: Date, lastUpdate: TimeInterval, shouldSkip: Bool) = stateLock.withLock { state in
+            if state.startTime == nil { state.startTime = Date() }
+            let now = Date().timeIntervalSinceReferenceDate
+            let isFinalUpdate = total > 0 && completed >= total
+            let shouldSkip = !isFinalUpdate && state.lastMetricsUpdateTime > 0 &&
+                now - state.lastMetricsUpdateTime < Self.metricsUpdateInterval
+            if !shouldSkip {
+                state.lastMetricsUpdateTime = now
+            }
+            return (state.startTime!, state.lastMetricsUpdateTime, shouldSkip)
         }
-        if startTime == nil { startTime = Date() }
 
-        let now = Date().timeIntervalSinceReferenceDate
-        let isFinalUpdate = total > 0 && completed >= total
-        if !isFinalUpdate && lastMetricsUpdateTime > 0 &&
-            now - lastMetricsUpdateTime < Self.metricsUpdateInterval
-        {
-            return
-        }
-        lastMetricsUpdateTime = now
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if total > 0 {
+                self.ensureDeterminateProgressOnMain()
+                self.progressBar.doubleValue = Double(completed) / Double(total)
+            }
 
-        let completedStr = ByteCountFormatter.string(fromByteCount: Int64(completed), countStyle: .file)
-        let totalStr = ByteCountFormatter.string(fromByteCount: Int64(total), countStyle: .file)
-        let percent = total > 0 ? Int(Double(completed) / Double(total) * 100) : 0
-        bytesLabel.stringValue = "\(completedStr) / \(totalStr) (\(percent)%)"
+            guard !metrics.shouldSkip else { return }
 
-        // Speed and ETA calculation (like ProgressDialog2.cpp)
-        if let start = startTime {
-            let elapsed = Date().timeIntervalSince(start)
+            let completedStr = ByteCountFormatter.string(fromByteCount: Int64(completed), countStyle: .file)
+            let totalStr = ByteCountFormatter.string(fromByteCount: Int64(total), countStyle: .file)
+            let percent = total > 0 ? Int(Double(completed) / Double(total) * 100) : 0
+            self.bytesLabel.stringValue = "\(completedStr) / \(totalStr) (\(percent)%)"
+
+            let elapsed = Date().timeIntervalSince(metrics.startTime)
             if elapsed > Self.metricsUpdateInterval {
                 let speed = Double(completed) / elapsed
                 let speedStr = ByteCountFormatter.string(fromByteCount: Int64(speed), countStyle: .file)
-                speedLabel.stringValue = "Speed: \(speedStr)/s"
+                self.speedLabel.stringValue = "Speed: \(speedStr)/s"
 
-                let elapsedStr = formatDuration(elapsed)
+                let elapsedStr = self.formatDuration(elapsed)
                 if total > 0, completed > 0 {
                     let remaining = elapsed * Double(total - completed) / Double(completed)
-                    let remainStr = formatDuration(remaining)
-                    elapsedLabel.stringValue = "Elapsed: \(elapsedStr)  Remaining: \(remainStr)"
+                    let remainStr = self.formatDuration(remaining)
+                    self.elapsedLabel.stringValue = "Elapsed: \(elapsedStr)  Remaining: \(remainStr)"
                 } else {
-                    elapsedLabel.stringValue = "Elapsed: \(elapsedStr)"
+                    self.elapsedLabel.stringValue = "Elapsed: \(elapsedStr)"
                 }
             }
         }
@@ -252,13 +274,16 @@ class ProgressDialogController: NSWindowController, SZProgressDelegate {
     }
 
     @objc func progressShouldCancel() -> Bool {
-        return cancelled
+        return stateLock.withLock { $0.cancelled }
     }
 
     func progressDidUpdateFilesCompleted(_ count: UInt64) {
-        if speedLabel.stringValue.isEmpty || speedLabel.stringValue.hasSuffix("processed") {
-            let suffix = count == 1 ? "file" : "files"
-            speedLabel.stringValue = "\(count) \(suffix) processed"
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if self.speedLabel.stringValue.isEmpty || self.speedLabel.stringValue.hasSuffix("processed") {
+                let suffix = count == 1 ? "file" : "files"
+                self.speedLabel.stringValue = "\(count) \(suffix) processed"
+            }
         }
     }
 
@@ -267,9 +292,12 @@ class ProgressDialogController: NSWindowController, SZProgressDelegate {
     }
 
     @objc func progressResetCancellationRequest() {
-        cancelled = false
-        cancelButton.isEnabled = false
-        cancelButton.title = "Finalizing..."
+        stateLock.withLock { $0.cancelled = false }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.cancelButton.isEnabled = false
+            self.cancelButton.title = "Finalizing..."
+        }
     }
 
     @objc func progressDidUpdateSpeed(_: Double) {

--- a/ShichiZip/FileManager/FileManagerArchiveItemWorkflowService.swift
+++ b/ShichiZip/FileManager/FileManagerArchiveItemWorkflowService.swift
@@ -178,9 +178,11 @@ final class FileManagerArchiveItemWorkflowService {
                 }
 
             case .cancelled:
+                cleanup(stagedItem.temporaryDirectory)
                 return
 
             case let .failed(error):
+                cleanup(stagedItem.temporaryDirectory)
                 throw error
             }
 
@@ -196,9 +198,13 @@ final class FileManagerArchiveItemWorkflowService {
                                      nestedWriteBackInfo,
                                      openMode)
             {
-            case .opened, .cancelled:
+            case .opened:
+                return
+            case .cancelled:
+                cleanup(stagedItem.temporaryDirectory)
                 return
             case let .unsupportedArchive(error), let .failed(error):
+                cleanup(stagedItem.temporaryDirectory)
                 throw error
             }
 

--- a/ShichiZip/FileManager/FileManagerPaneController.swift
+++ b/ShichiZip/FileManager/FileManagerPaneController.swift
@@ -3307,7 +3307,7 @@ class FileManagerPaneController: NSViewController, NSTableViewDataSource, NSTabl
                 .appendingPathComponent(sourceURL.lastPathComponent)
                 .standardizedFileURL
 
-            if sourceURL == destinationFileURL {
+            if sourceURL.standardizedFileURL.path.lowercased() == destinationFileURL.path.lowercased() {
                 continue
             }
 
@@ -3387,7 +3387,12 @@ class FileManagerPaneController: NSViewController, NSTableViewDataSource, NSTabl
         }
 
         try copyDroppedItemPreservingMetadata(from: sourceURL, to: destinationURL)
-        try FileManager.default.removeItem(at: sourceURL)
+        do {
+            try FileManager.default.removeItem(at: sourceURL)
+        } catch {
+            try? FileManager.default.removeItem(at: destinationURL)
+            throw error
+        }
     }
 
     private func copyDroppedItemPreservingMetadata(from sourceURL: URL,

--- a/ShichiZip/FileManager/FileManagerWindowController.swift
+++ b/ShichiZip/FileManager/FileManagerWindowController.swift
@@ -1075,6 +1075,7 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                         try archive.open(atPath: archiveURL.path,
                                          password: extractResult.password,
                                          session: session)
+                        defer { archive.close() }
                         let archiveItems = archive.entries().map(ArchiveItem.init)
                         let settings = SZExtractionSettings()
                         settings.overwriteMode = extractResult.overwriteMode
@@ -1092,7 +1093,6 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                         try archive.extract(toPath: extractResult.destinationURL.path,
                                             settings: settings,
                                             session: session)
-                        archive.close()
                     }
                 }
 
@@ -1142,8 +1142,8 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                         }
                         let archive = SZArchive()
                         try archive.open(atPath: archiveURL.path, session: session)
+                        defer { archive.close() }
                         try archive.test(with: session)
-                        archive.close()
                     }
                 }
                 szPresentMessage(title: "Test OK",
@@ -2014,7 +2014,7 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
 
         do {
             try archive.open(atPath: url.path)
-            archive.close()
+            defer { archive.close() }
             return true
         } catch {
             let nsError = error as NSError

--- a/ShichiZip/Utilities/DialogPresenter.swift
+++ b/ShichiZip/Utilities/DialogPresenter.swift
@@ -57,23 +57,40 @@ func szRunChoiceDialog(title: String,
                        style: SZDialogStyle = .informational,
                        buttons: [String]) -> Int
 {
-    SZDialogPresenter.runMessage(with: style,
-                                 title: title,
-                                 message: message,
-                                 buttonTitles: buttons)
+    if Thread.isMainThread {
+        return SZDialogPresenter.runMessage(with: style,
+                                            title: title,
+                                            message: message,
+                                            buttonTitles: buttons)
+    } else {
+        return DispatchQueue.main.sync {
+            SZDialogPresenter.runMessage(with: style,
+                                         title: title,
+                                         message: message,
+                                         buttonTitles: buttons)
+        }
+    }
 }
 
 func szPromptForPasswordSync(title: String,
                              message: String? = nil,
                              initialValue: String? = nil) -> String?
 {
-    var password: NSString?
-    let confirmed = SZDialogPresenter.promptForPassword(withTitle: title,
-                                                        message: message,
-                                                        initialValue: initialValue,
-                                                        password: &password)
-    guard confirmed else { return nil }
-    return password as String?
+    let doPrompt = { () -> String? in
+        var password: NSString?
+        let confirmed = SZDialogPresenter.promptForPassword(withTitle: title,
+                                                            message: message,
+                                                            initialValue: initialValue,
+                                                            password: &password)
+        guard confirmed else { return nil }
+        return password as String?
+    }
+
+    if Thread.isMainThread {
+        return doPrompt()
+    } else {
+        return DispatchQueue.main.sync(execute: doPrompt)
+    }
 }
 
 func szBeginConfirmation(on window: NSWindow,


### PR DESCRIPTION
## Summary

This PR fixes several bugs across the codebase:

### Thread Safety (ProgressDialogController, SZCallbacks, DialogPresenter)
- Protect `cancelled`/`startTime`/`lastMetricsUpdateTime`/`isWaitingForProgress` with `OSAllocatedUnfairLock` to eliminate data races between the 7-Zip worker thread and the main thread
- Dispatch all UI updates to the main thread via `DispatchQueue.main.async`
- Replace shared static `NSDateFormatter` with per-call instance in `SZFormatFileTime` (NSDateFormatter is not thread-safe)
- Add main-thread guards to `szRunChoiceDialog` and `szPromptForPasswordSync`

### Resource Leaks (FileManagerWindowController)
- Use `defer { archive.close() }` in `extractArchive`, `testArchive`, and `isArchiveFile` so handles are released even when operations throw

### Temporary Directory Leaks (FileManagerArchiveItemWorkflowService)
- Clean up staged temporary directories on `.cancelled` and `.failed` paths (previously only `.unsupportedArchive` cleaned up)

### Logic Errors
- **SZArchive.mm**: Add `default` case to `SZCompressionMethodSpec` switch to prevent undefined behavior
- **ExtractDialogController**: Guard against `indexOfSelectedItem` returning -1 before array subscript
- **CompressDialogController**: Replace `NSUserCancelledError` with `NSFormattingError` for validation errors — `NSUserCancelledError` is silently suppressed by standard Cocoa error presentation
- **FileManagerPaneController**: Use case-insensitive path comparison for macOS APFS (default case-insensitive filesystem)
- **FileManagerPaneController**: Clean up destination copy when source removal fails during cross-volume move fallback