### PR TITLE
Localize date format menu and update zh-CN strings

### DIFF
--- a/ShichiZip/Resources/Localization/zh-Hans.lproj/App.strings
+++ b/ShichiZip/Resources/Localization/zh-Hans.lproj/App.strings
@@ -218,4 +218,3 @@
 "tools.deleteTempFiles" = "删除临时文件...";
 
 "view.openRootFolder" = "打开根目录";
-"view.twoPanels" = "双列显示";

--- a/ShichiZip/Resources/Localization/zh-Hans.lproj/App.strings
+++ b/ShichiZip/Resources/Localization/zh-Hans.lproj/App.strings
@@ -202,10 +202,20 @@
 "app.shortcut.toggleDualPane" = "切换双栏";
 
 "app.view.unifiedToolbarStyle" = "统一样式";
+"archive.cannotStartEditor" = "无法启动外部编辑器。";
 
 "benchmark.passes" = "轮数：";
+
+"column.hostOS" = "宿主系统";
 
 "compress.browse" = "浏览…";
 "compress.createSFX" = "创建 Windows 自解压程序";
 
+"extract.eliminateDuplication" = "排除重复的根目录";
+
 "shell.openArchive" = "打开压缩包…";
+
+"tools.deleteTempFiles" = "删除临时文件...";
+
+"view.openRootFolder" = "打开根目录";
+"view.twoPanels" = "双列显示";


### PR DESCRIPTION
Replace hard-coded time preview title with localized key SZL10n.string("app.menu.dateFormat") in MainMenu. Update project/localization/Lang/zh-cn.txt with a version/date bump and several Chinese wording fixes.