### PR TITLE
feat(build): wrap archive core in shared frameworks

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -35,7 +35,7 @@ ShichiZip ships in two variants that share the same app code but link against di
 - **Mainline** (`ShichiZip`): linked against `vendor/7zip` ([ip7z/7zip](https://github.com/ip7z/7zip)).
 - **Zstandard fork** (`ShichiZipZS`): linked against `vendor/7zip-zstd` ([mcmilk/7-Zip-zstd](https://github.com/mcmilk/7-Zip-zstd)), adding Zstandard and a few other codecs.
 
-Each build is two steps: build the C/C++ static library and the Windows SFX modules with Zig, then build the macOS app with Xcode.
+Each build is two steps: build the C/C++ static archive and the Windows SFX modules with Zig, then build the macOS app with Xcode. Xcode wraps the static archive in an embedded ArchiveCore framework so the main app and archive Quick Look extension can share one dynamic image.
 
 ### 1. Generate the Xcode project
 
@@ -55,7 +55,7 @@ SHICHIZIP_UNSIGNED=true xcodegen generate
 
 The unsigned project uses the same `project.yml` and conditionally includes an unsigned signing overlay. It disables code signing for Debug and Release, but it is not suitable for packaging, release, signature verification, or validating Quick Action app-group behavior. Run `xcodegen generate` again without `SHICHIZIP_UNSIGNED` to restore the normal signing project.
 
-### 2. Build the upstream library with Zig
+### 2. Build the upstream static archive with Zig
 
 Mainline:
 
@@ -69,7 +69,7 @@ Zstandard fork:
 zig build lib -Dvariant=zs -Dtarget=aarch64-native -Doptimize=ReleaseFast -p build
 ```
 
-Output goes to `build/lib/`. Substitute `-Dtarget=x86_64-native` for Intel builds.
+Output goes to `build/lib/`. Substitute `-Dtarget=x86_64-native` for Intel builds. Xcode links this static archive into the matching `ShichiZipArchiveCore.framework` / `ShichiZipZSArchiveCore.framework`.
 
 ### 3. Build the Windows SFX modules
 
@@ -152,16 +152,16 @@ project/
 ├── localization/      Source localization data (see README)
 └── generated/         Files produced by xcodegen / scripts (gitignored)
 
-build.zig              Zig build script for the static library and SFX modules
+build.zig              Zig build script for the static archive and SFX modules
 build.zig.zon          Zig package manifest
 project.yml            XcodeGen entry point (includes project/specs/*.yml)
 ```
 
 ### Flow
 
-- **`build.zig`** patches the vendored 7-Zip tree (via `vendor/apply_7zip_patches.sh`), then compiles the macOS static library (including the Objective-C++ shims in `vendor/SZ*.mm`) and the Windows SFX modules. Source tarballs from release artifacts contain a `.build-metadata` file and will skip the patch step, since their sources are already patched.
+- **`build.zig`** patches the vendored 7-Zip tree (via `vendor/apply_7zip_patches.sh`), then compiles the macOS static archive (including the Objective-C++ shims in `vendor/SZ*.mm`) and the Windows SFX modules. Source tarballs from release artifacts contain a `.build-metadata` file and will skip the patch step, since their sources are already patched.
 - **`xcodegen`** consumes `project.yml` (which includes the specs under `project/specs/`) to generate `ShichiZip.xcodeproj`. It also runs the localization generators in `project/scripts/` to produce the files under `project/generated/` and the `InfoPlist.strings` for Quick Actions. Re-run `xcodegen generate` after editing any spec or localization source. Source tarballs from release artifacts ship with `ShichiZip.xcodeproj` and the generated localization files already in place, so this step can be skipped when building from a tarball.
-- **Xcode** builds the app, links against the static library produced by Zig in `build/lib/`, and embeds the Quick Action extensions and the specific SFX module from `build/sfx/`.
+- **Xcode** builds the ArchiveCore framework by force-loading the static archive from `build/lib/`, then links the app and archive Quick Look extension against that framework. The app embeds/signs the framework in `Contents/Frameworks`, where the extension can load it through its runpath. Xcode also embeds the Quick Action extensions and the specific SFX module from `build/sfx/`.
 
 ## Reference
 

--- a/ShichiZip/Bridge/SZBridgeCommon.h
+++ b/ShichiZip/Bridge/SZBridgeCommon.h
@@ -104,6 +104,7 @@ static inline NSError* SZMakeDetailedError(NSInteger code, NSString* desc, NSStr
 }
 
 static NSString* const SZSharedUserDefaultsAppGroupIdentifierInfoKey = @"ShichiZipQuickActionAppGroupIdentifier";
+static NSString* const SZLocalizationBundleIdentifier = @"ee.dawn.ShichiZip.Localization";
 
 static inline NSUserDefaults* SZSharedNSUserDefaults(void) {
     NSString* appGroupIdentifier =
@@ -118,12 +119,44 @@ static inline NSUserDefaults* SZSharedNSUserDefaults(void) {
     return [NSUserDefaults standardUserDefaults];
 }
 
+static inline NSBundle* SZLocalizationBundle(void) {
+    NSBundle* bundle = [NSBundle bundleWithIdentifier:SZLocalizationBundleIdentifier];
+    if (bundle) {
+        return bundle;
+    }
+
+    NSMutableArray<NSURL*>* candidateURLs = [NSMutableArray array];
+    NSURL* privateFrameworksURL = [[NSBundle mainBundle] privateFrameworksURL];
+    if (privateFrameworksURL) {
+        [candidateURLs addObject:[privateFrameworksURL URLByAppendingPathComponent:@"ShichiZipLocalization.framework"
+                                                                       isDirectory:YES]];
+    }
+    [candidateURLs addObject:[[[NSBundle mainBundle] bundleURL]
+                                 URLByAppendingPathComponent:@"Contents/Frameworks/ShichiZipLocalization.framework"
+                                                 isDirectory:YES]];
+    [candidateURLs addObject:[[[[[NSBundle mainBundle] bundleURL] URLByDeletingLastPathComponent]
+                                 URLByDeletingLastPathComponent]
+                                 URLByAppendingPathComponent:@"Frameworks/ShichiZipLocalization.framework"
+                                                 isDirectory:YES]];
+
+    for (NSURL* candidateURL in candidateURLs) {
+        NSBundle* candidateBundle = [NSBundle bundleWithURL:candidateURL];
+        if ([candidateBundle.bundleIdentifier isEqualToString:SZLocalizationBundleIdentifier]) {
+            return candidateBundle;
+        }
+    }
+
+    return [NSBundle mainBundle];
+}
+
 /// Look up a localized string: checks App.strings first, then Upstream.strings.
 /// Mirrors the SZL10n.string() Swift API for use in Objective-C bridge code.
 static inline NSString* SZLocalizedString(NSString* key) {
+    NSBundle* baseBundle = SZLocalizationBundle();
+
     // Check override bundle from language preference
     NSString* override = [SZSharedNSUserDefaults() stringForKey:@"LanguageOverride"];
-    NSBundle* bundle = [NSBundle mainBundle];
+    NSBundle* bundle = baseBundle;
     if (override.length > 0) {
         NSString* lpath = [bundle pathForResource:override ofType:@"lproj"];
         if (lpath) {
@@ -141,7 +174,16 @@ static inline NSString* SZLocalizedString(NSString* key) {
     if (![upstreamValue isEqualToString:key])
         return upstreamValue;
     // Fallback to main bundle if override was active
-    if (bundle != [NSBundle mainBundle]) {
+    if (bundle != baseBundle) {
+        appValue = [baseBundle localizedStringForKey:key value:nil table:@"App"];
+        if (![appValue isEqualToString:key])
+            return appValue;
+        upstreamValue = [baseBundle localizedStringForKey:key value:nil table:@"Upstream"];
+        if (![upstreamValue isEqualToString:key])
+            return upstreamValue;
+    }
+
+    if (baseBundle != [NSBundle mainBundle]) {
         appValue = [[NSBundle mainBundle] localizedStringForKey:key value:nil table:@"App"];
         if (![appValue isEqualToString:key])
             return appValue;
@@ -149,6 +191,7 @@ static inline NSString* SZLocalizedString(NSString* key) {
         if (![upstreamValue isEqualToString:key])
             return upstreamValue;
     }
+
     return key;
 }
 

--- a/ShichiZip/QuickLookPreview/ArchivePreviewModel.swift
+++ b/ShichiZip/QuickLookPreview/ArchivePreviewModel.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+@_silgen_name("ShichiZipLocalizationFrameworkAnchor")
+private func ShichiZipLocalizationFrameworkAnchor()
+
 struct ArchivePreviewSnapshot {
     let archiveURL: URL
     let items: [ArchiveItem]
@@ -991,21 +994,57 @@ enum ArchivePreviewTreeBuilder {
 }
 
 enum ArchivePreviewLocalization {
+    private static let localizationBundleIdentifier = "ee.dawn.ShichiZip.Localization"
+
     static func string(_ key: String) -> String {
-        let mainBundle = Bundle.main
-        if let overrideBundle = languageOverrideBundle(in: mainBundle),
-           let value = lookup(key, in: overrideBundle) ?? lookup(key, in: mainBundle)
+        let bundle = baseBundle
+        if let overrideBundle = languageOverrideBundle(in: bundle),
+           let value = lookup(key, in: overrideBundle) ?? lookup(key, in: bundle) ?? lookup(key, in: .main)
         {
             return value
         }
 
-        return lookup(key, in: mainBundle) ?? key
+        return lookup(key, in: bundle) ?? lookup(key, in: .main) ?? key
     }
 
     static func string(_ key: String,
                        _ args: any CVarArg...) -> String
     {
         String(format: string(key), arguments: args)
+    }
+
+    private static let localizationFrameworkAnchor: Void = {
+        ShichiZipLocalizationFrameworkAnchor()
+    }()
+
+    private static var baseBundle: Bundle {
+        _ = localizationFrameworkAnchor
+        return localizationBundle() ?? .main
+    }
+
+    private static func localizationBundle() -> Bundle? {
+        if let bundle = Bundle(identifier: localizationBundleIdentifier) {
+            return bundle
+        }
+
+        let candidateURLs = [
+            Bundle.main.privateFrameworksURL?.appendingPathComponent("ShichiZipLocalization.framework", isDirectory: true),
+            Bundle.main.bundleURL.appendingPathComponent("Contents/Frameworks/ShichiZipLocalization.framework", isDirectory: true),
+            Bundle.main.bundleURL
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Frameworks/ShichiZipLocalization.framework", isDirectory: true),
+        ]
+
+        for url in candidateURLs.compactMap(\.self) {
+            if let bundle = Bundle(url: url),
+               bundle.bundleIdentifier == localizationBundleIdentifier
+            {
+                return bundle
+            }
+        }
+
+        return nil
     }
 
     private static func languageOverrideBundle(in bundle: Bundle) -> Bundle? {

--- a/ShichiZip/Resources/Localization/zh-Hans.lproj/App.strings
+++ b/ShichiZip/Resources/Localization/zh-Hans.lproj/App.strings
@@ -176,7 +176,7 @@
 "app.settings.defaultOpeners" = "默认打开方式";
 "app.settings.defaultOpenersDescription" = "选择要让 %@ 在访达中作为默认打开方式的压缩包类型。macOS 可能会要求你确认。";
 "app.settings.defaultOpenersNote" = "已经由本应用作为默认打开方式的类型会显示为「当前默认应用」。如果之后要切换回其他应用，请使用访达的「打开方式」设置或其他应用自己的集成设置。";
-"app.settings.excludeMacResourceForks" = "默认排除 macOS 资源分支文件";
+"app.settings.excludeMacResourceForks" = "默认排除 macOS 资源文件";
 "app.settings.extraction" = "解压";
 "app.settings.finderLike" = "Finder 风格";
 "app.settings.finderLikeDescription" = "使用 macOS 风格的文件管理器快捷键，包括按 Return 重命名和 Command+方向键导航。";

--- a/ShichiZip/Utilities/SZL10n.swift
+++ b/ShichiZip/Utilities/SZL10n.swift
@@ -1,6 +1,9 @@
 import Foundation
 import os
 
+@_silgen_name("ShichiZipLocalizationFrameworkAnchor")
+private func ShichiZipLocalizationFrameworkAnchor()
+
 /// Centralized lookup for localized UI strings.
 ///
 /// Strings sourced from the upstream 7-Zip translation project live in
@@ -21,6 +24,8 @@ import os
 /// let label = SZL10n.string("app.extract.moveToTrash")
 /// ```
 enum SZL10n {
+    static let localizationBundleIdentifier = "ee.dawn.ShichiZip.Localization"
+
     /// The bundle used for string lookups. Points at the chosen
     /// `.lproj` inside `Resources/Localization` when an override
     /// is active, otherwise falls back to `.main`.
@@ -53,7 +58,10 @@ enum SZL10n {
         if let found = lookup(key, in: b) {
             return found
         }
-        // When an override bundle is active, fall back to .main
+        if b !== baseBundle, let found = lookup(key, in: baseBundle) {
+            return found
+        }
+        // Fall back to .main for unsigned/ad-hoc builds or older bundles.
         if b !== Bundle.main, let found = lookup(key, in: .main) {
             return found
         }
@@ -83,19 +91,12 @@ enum SZL10n {
     }
 
     /// Returns all available languages sorted by display name,
-    /// based on which `.lproj` folders exist in the app bundle's Resources.
+    /// based on which `.lproj` folders exist in the localization bundle.
     static func availableLanguages() -> [Language] {
-        guard let resourceURL = Bundle.main.resourceURL,
-              let contents = try? FileManager.default.contentsOfDirectory(at: resourceURL,
-                                                                          includingPropertiesForKeys: nil)
-        else {
-            return []
-        }
-
         var languages: [Language] = []
-        for url in contents {
-            guard url.pathExtension == "lproj" else { continue }
-            let code = url.deletingPathExtension().lastPathComponent
+        let localeCodes = availableLocaleCodes(in: baseBundle)
+
+        for code in localeCodes {
             if code == "en" || code == "Base" { continue }
 
             let nativeLocale = Locale(identifier: code)
@@ -119,17 +120,62 @@ enum SZL10n {
 
     // MARK: - Private
 
+    private static let localizationFrameworkAnchor: Void = {
+        ShichiZipLocalizationFrameworkAnchor()
+    }()
+
+    private static var baseBundle: Bundle {
+        _ = localizationFrameworkAnchor
+        return localizationBundle() ?? .main
+    }
+
+    private static func localizationBundle() -> Bundle? {
+        if let bundle = Bundle(identifier: localizationBundleIdentifier) {
+            return bundle
+        }
+
+        let candidateURLs = [
+            Bundle.main.privateFrameworksURL?.appendingPathComponent("ShichiZipLocalization.framework", isDirectory: true),
+            Bundle.main.bundleURL.appendingPathComponent("Contents/Frameworks/ShichiZipLocalization.framework", isDirectory: true),
+            Bundle.main.bundleURL
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Frameworks/ShichiZipLocalization.framework", isDirectory: true),
+        ]
+
+        for url in candidateURLs.compactMap(\.self) {
+            if let bundle = Bundle(url: url),
+               bundle.bundleIdentifier == localizationBundleIdentifier
+            {
+                return bundle
+            }
+        }
+
+        return nil
+    }
+
+    private static func availableLocaleCodes(in bundle: Bundle) -> Set<String> {
+        var codes = Set(bundle.localizations)
+
+        for path in bundle.paths(forResourcesOfType: "lproj", inDirectory: nil) {
+            codes.insert(URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent)
+        }
+
+        return codes
+    }
+
     private static func makeBundle() -> Bundle {
         let override = SZSettings.string(.languageOverride)
-        guard !override.isEmpty else { return .main }
+        let bundle = baseBundle
+        guard !override.isEmpty else { return bundle }
 
-        // Look for the lproj in the main bundle's Resources
-        if let path = Bundle.main.path(forResource: override, ofType: "lproj"),
+        // Look for the lproj in the shared localization bundle's Resources
+        if let path = bundle.path(forResource: override, ofType: "lproj"),
            let overrideBundle = Bundle(path: path)
         {
             return overrideBundle
         }
 
-        return .main
+        return bundle
     }
 }

--- a/ShichiZipTests/QuickLookPreviewExtensionEntryTests.swift
+++ b/ShichiZipTests/QuickLookPreviewExtensionEntryTests.swift
@@ -10,10 +10,11 @@ final class QuickLookPreviewExtensionEntryTests: XCTestCase {
         XCTAssertTrue(previewController is NSViewController)
     }
 
-    func testQuickLookPreviewExtensionIncludesAppLocalizations() throws {
-        let appexBundle = try loadQuickLookBundle(named: Self.quickLookPreviewAppexName)
-        let englishLocalizationPath = try XCTUnwrap(appexBundle.path(forResource: "en",
-                                                                     ofType: "lproj"))
+    func testQuickLookPreviewUsesSharedLocalizationFramework() throws {
+        _ = try loadQuickLookBundle(named: Self.quickLookPreviewAppexName)
+        let localizationBundle = try loadLocalizationBundle()
+        let englishLocalizationPath = try XCTUnwrap(localizationBundle.path(forResource: "en",
+                                                                            ofType: "lproj"))
         let englishLocalizationBundle = try XCTUnwrap(Bundle(path: englishLocalizationPath))
 
         let key = "app.archive.error.operationCancelled"
@@ -21,6 +22,15 @@ final class QuickLookPreviewExtensionEntryTests: XCTestCase {
                                                                  value: nil,
                                                                  table: "App"),
                        "Operation was cancelled")
+    }
+
+    private func loadLocalizationBundle() throws -> Bundle {
+        let plugInsURL = try XCTUnwrap(Bundle.main.builtInPlugInsURL)
+        let frameworkURL = plugInsURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("Frameworks", isDirectory: true)
+            .appendingPathComponent("ShichiZipLocalization.framework", isDirectory: true)
+        return try XCTUnwrap(Bundle(url: frameworkURL))
     }
 
     private func loadPreviewController(from appexName: String) throws -> QLPreviewingController {

--- a/project.yml
+++ b/project.yml
@@ -2,6 +2,7 @@ name: ShichiZip
 
 include:
   - project/specs/base.yml
+  - project/specs/archive-core.yml
   - project/specs/apps.yml
   - project/specs/quick-actions.yml
   - project/specs/quicklook-preview.yml

--- a/project.yml
+++ b/project.yml
@@ -3,6 +3,7 @@ name: ShichiZip
 include:
   - project/specs/base.yml
   - project/specs/archive-core.yml
+  - project/specs/localization.yml
   - project/specs/apps.yml
   - project/specs/quick-actions.yml
   - project/specs/quicklook-preview.yml

--- a/project/archive-core/SZArchiveCoreInitGuid.cpp
+++ b/project/archive-core/SZArchiveCoreInitGuid.cpp
@@ -1,0 +1,8 @@
+// Defines 7-Zip COM GUID constants inside the shared archive core dylib.
+#define INITGUID
+
+#include "CPP/7zip/Archive/IArchive.h"
+#include "CPP/7zip/ICoder.h"
+#include "CPP/7zip/IPassword.h"
+#include "CPP/7zip/IStream.h"
+#include "CPP/7zip/UI/Common/IFileExtractCallback.h"

--- a/project/localization-framework/ShichiZipLocalizationAnchor.m
+++ b/project/localization-framework/ShichiZipLocalizationAnchor.m
@@ -1,0 +1,1 @@
+void ShichiZipLocalizationFrameworkAnchor(void) { }

--- a/project/specs/apps.yml
+++ b/project/specs/apps.yml
@@ -17,6 +17,8 @@ targets:
           - "QuickLookPreview/Extension/**"
     dependencies:
       - sdk: AppIntents.framework
+      - target: ShichiZipArchiveCore
+        embed: true
       - target: ShichiZipRevealInFileManagerAction
         embed: true
       - target: ShichiZipOpenInShichiZipAction
@@ -36,26 +38,10 @@ targets:
             - $(PROJECT_DIR)/$(SEVENZ_VENDOR_ROOT)
             - $(PROJECT_DIR)/$(SEVENZ_VENDOR_ROOT)/CPP
             - $(PROJECT_DIR)/$(SEVENZ_VENDOR_ROOT)/C
-          LIBRARY_SEARCH_PATHS:
-            - $(inherited)
-          'LIBRARY_SEARCH_PATHS[arch=arm64]':
-            - $(inherited)
-            - $(PROJECT_DIR)/build/lib/arm64
-          'LIBRARY_SEARCH_PATHS[arch=x86_64]':
-            - $(inherited)
-            - $(PROJECT_DIR)/build/lib/x86_64
           OTHER_LDFLAGS:
             - $(inherited)
             - -liconv
             - -lpthread
-          'OTHER_LDFLAGS[arch=arm64]':
-            - $(inherited)
-            - -force_load
-            - $(PROJECT_DIR)/build/lib/arm64/$(SEVENZ_LIBRARY_NAME)
-          'OTHER_LDFLAGS[arch=x86_64]':
-            - $(inherited)
-            - -force_load
-            - $(PROJECT_DIR)/build/lib/x86_64/$(SEVENZ_LIBRARY_NAME)
           MACOSX_DEPLOYMENT_TARGET: "13.0"
           GENERATE_INFOPLIST_FILE: false
           CLANG_ENABLE_OBJC_ARC: true
@@ -85,6 +71,7 @@ targets:
       - path: ../../ShichiZipTests
     dependencies:
       - target: ShichiZip
+      - target: ShichiZipArchiveCore
       - sdk: AppIntents.framework
     settings:
       base:
@@ -95,6 +82,9 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: ShichiZipTests/ShichiZipTests-Bridging-Header.h
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/ShichiZip.app/Contents/MacOS/ShichiZip
         BUNDLE_LOADER: $(TEST_HOST)
+        LD_RUNPATH_SEARCH_PATHS:
+          - $(inherited)
+          - "@loader_path/../../../../Frameworks"
 
   ShichiZipUITests:
     type: bundle.ui-testing
@@ -119,6 +109,7 @@ targets:
       - path: ../../ShichiZipTests
     dependencies:
       - target: ShichiZipZS
+      - target: ShichiZipZSArchiveCore
       - sdk: AppIntents.framework
     settings:
       base:
@@ -129,6 +120,9 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: ShichiZipTests/ShichiZipTests-Bridging-Header.h
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/ShichiZip ZS.app/Contents/MacOS/ShichiZip ZS
         BUNDLE_LOADER: $(TEST_HOST)
+        LD_RUNPATH_SEARCH_PATHS:
+          - $(inherited)
+          - "@loader_path/../../../../Frameworks"
         SWIFT_ACTIVE_COMPILATION_CONDITIONS:
           - "$(inherited)"
           - "SHICHIZIP_ZS_VARIANT"
@@ -159,6 +153,8 @@ targets:
     sources: *app_sources
     dependencies:
       - sdk: AppIntents.framework
+      - target: ShichiZipZSArchiveCore
+        embed: true
       - target: ShichiZipZSRevealInFileManagerAction
         embed: true
       - target: ShichiZipZSOpenInShichiZipAction

--- a/project/specs/apps.yml
+++ b/project/specs/apps.yml
@@ -13,10 +13,13 @@ targets:
       - path: ../../ShichiZip
         excludes: &app_source_excludes
           - "**/*.entitlements"
+          - "Resources/Localization/**"
           - "QuickActions/Extensions/**"
           - "QuickLookPreview/Extension/**"
     dependencies:
       - sdk: AppIntents.framework
+      - target: ShichiZipLocalization
+        embed: true
       - target: ShichiZipArchiveCore
         embed: true
       - target: ShichiZipRevealInFileManagerAction
@@ -153,6 +156,8 @@ targets:
     sources: *app_sources
     dependencies:
       - sdk: AppIntents.framework
+      - target: ShichiZipLocalization
+        embed: true
       - target: ShichiZipZSArchiveCore
         embed: true
       - target: ShichiZipZSRevealInFileManagerAction

--- a/project/specs/archive-core.yml
+++ b/project/specs/archive-core.yml
@@ -1,0 +1,69 @@
+targets:
+  ShichiZipArchiveCore:
+    type: framework
+    platform: macOS
+    postBuildScripts: &archive_core_build_metadata
+      - name: Generate Build Metadata
+        basedOnDependencyAnalysis: false
+        inputFiles:
+          - $(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)
+        script: |
+          sh "${SRCROOT}/project/scripts/generate-build-metadata.sh"
+    sources:
+      - &archive_core_guid_source
+        path: ../archive-core/SZArchiveCoreInitGuid.cpp
+    dependencies: &archive_core_dependencies
+      - sdk: CoreFoundation.framework
+      - sdk: Foundation.framework
+    settings:
+      base:
+        <<: &archive_core_mainline_settings
+          PRODUCT_BUNDLE_IDENTIFIER: ee.dawn.ShichiZip.ArchiveCore
+          PRODUCT_NAME: ShichiZipArchiveCore
+          MACOSX_DEPLOYMENT_TARGET: "13.0"
+          GENERATE_INFOPLIST_FILE: true
+          DEFINES_MODULE: false
+          APPLICATION_EXTENSION_API_ONLY: true
+          CLANG_CXX_LANGUAGE_STANDARD: c++23
+          CLANG_WARN_DOCUMENTATION_COMMENTS: false
+          HEADER_SEARCH_PATHS:
+            - $(PROJECT_DIR)/vendor/7zip
+            - $(PROJECT_DIR)/vendor/7zip/CPP
+            - $(PROJECT_DIR)/vendor/7zip/C
+          OTHER_LDFLAGS:
+            - $(inherited)
+            - -liconv
+            - -lpthread
+          'OTHER_LDFLAGS[arch=arm64]':
+            - $(inherited)
+            - -force_load
+            - $(PROJECT_DIR)/build/lib/arm64/lib7zip.a
+          'OTHER_LDFLAGS[arch=x86_64]':
+            - $(inherited)
+            - -force_load
+            - $(PROJECT_DIR)/build/lib/x86_64/lib7zip.a
+
+  ShichiZipZSArchiveCore:
+    type: framework
+    platform: macOS
+    postBuildScripts: *archive_core_build_metadata
+    sources:
+      - *archive_core_guid_source
+    dependencies: *archive_core_dependencies
+    settings:
+      base:
+        <<: *archive_core_mainline_settings
+        PRODUCT_BUNDLE_IDENTIFIER: ee.dawn.ShichiZipZS.ArchiveCore
+        PRODUCT_NAME: ShichiZipZSArchiveCore
+        HEADER_SEARCH_PATHS:
+          - $(PROJECT_DIR)/vendor/7zip-zstd
+          - $(PROJECT_DIR)/vendor/7zip-zstd/CPP
+          - $(PROJECT_DIR)/vendor/7zip-zstd/C
+        'OTHER_LDFLAGS[arch=arm64]':
+          - $(inherited)
+          - -force_load
+          - $(PROJECT_DIR)/build/lib/arm64/lib7zip-zs.a
+        'OTHER_LDFLAGS[arch=x86_64]':
+          - $(inherited)
+          - -force_load
+          - $(PROJECT_DIR)/build/lib/x86_64/lib7zip-zs.a

--- a/project/specs/archive-core.yml
+++ b/project/specs/archive-core.yml
@@ -26,6 +26,7 @@ targets:
           APPLICATION_EXTENSION_API_ONLY: true
           CLANG_CXX_LANGUAGE_STANDARD: c++23
           CLANG_WARN_DOCUMENTATION_COMMENTS: false
+          STRIP_STYLE: non-global
           HEADER_SEARCH_PATHS:
             - $(PROJECT_DIR)/vendor/7zip
             - $(PROJECT_DIR)/vendor/7zip/CPP

--- a/project/specs/localization.yml
+++ b/project/specs/localization.yml
@@ -1,0 +1,26 @@
+targets:
+  ShichiZipLocalization:
+    type: framework
+    platform: macOS
+    postBuildScripts:
+      - name: Generate Build Metadata
+        basedOnDependencyAnalysis: false
+        inputFiles:
+          - $(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)
+        script: |
+          sh "${SRCROOT}/project/scripts/generate-build-metadata.sh"
+    sources:
+      - path: ../localization-framework/ShichiZipLocalizationAnchor.m
+      - path: ../../ShichiZip/Resources/Localization
+        buildPhase: resources
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: ee.dawn.ShichiZip.Localization
+        PRODUCT_NAME: ShichiZipLocalization
+        MACOSX_DEPLOYMENT_TARGET: "13.0"
+        GENERATE_INFOPLIST_FILE: true
+        DEFINES_MODULE: false
+        APPLICATION_EXTENSION_API_ONLY: true
+        CLANG_ENABLE_OBJC_ARC: true
+        CLANG_WARN_DOCUMENTATION_COMMENTS: false
+        STRIP_STYLE: non-global

--- a/project/specs/quicklook-preview.yml
+++ b/project/specs/quicklook-preview.yml
@@ -31,6 +31,7 @@ targets:
       - sdk: AppKit.framework
       - sdk: QuickLookUI.framework
       - sdk: UniformTypeIdentifiers.framework
+      - target: ShichiZipArchiveCore
     settings:
       base:
         <<: &archive_preview_mainline_settings
@@ -41,26 +42,14 @@ targets:
             - $(PROJECT_DIR)/$(SEVENZ_VENDOR_ROOT)
             - $(PROJECT_DIR)/$(SEVENZ_VENDOR_ROOT)/CPP
             - $(PROJECT_DIR)/$(SEVENZ_VENDOR_ROOT)/C
-          LIBRARY_SEARCH_PATHS:
-            - $(inherited)
-          'LIBRARY_SEARCH_PATHS[arch=arm64]':
-            - $(inherited)
-            - $(PROJECT_DIR)/build/lib/arm64
-          'LIBRARY_SEARCH_PATHS[arch=x86_64]':
-            - $(inherited)
-            - $(PROJECT_DIR)/build/lib/x86_64
           OTHER_LDFLAGS:
             - $(inherited)
             - -liconv
             - -lpthread
-          'OTHER_LDFLAGS[arch=arm64]':
+          LD_RUNPATH_SEARCH_PATHS:
             - $(inherited)
-            - -force_load
-            - $(PROJECT_DIR)/build/lib/arm64/$(SEVENZ_LIBRARY_NAME)
-          'OTHER_LDFLAGS[arch=x86_64]':
-            - $(inherited)
-            - -force_load
-            - $(PROJECT_DIR)/build/lib/x86_64/$(SEVENZ_LIBRARY_NAME)
+            - "@executable_path/../Frameworks"
+            - "@executable_path/../../../../Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "13.0"
           GENERATE_INFOPLIST_FILE: false
           APPLICATION_EXTENSION_API_ONLY: true
@@ -173,7 +162,11 @@ targets:
       - *archive_preview_log_source
       - *archive_preview_shared_defaults_source
       - *archive_preview_localization_resources
-    dependencies: *archive_preview_dependencies
+    dependencies:
+      - sdk: AppKit.framework
+      - sdk: QuickLookUI.framework
+      - sdk: UniformTypeIdentifiers.framework
+      - target: ShichiZipZSArchiveCore
     settings:
       base:
         <<: *archive_preview_mainline_settings

--- a/project/specs/quicklook-preview.yml
+++ b/project/specs/quicklook-preview.yml
@@ -24,13 +24,11 @@ targets:
         path: ../../ShichiZip/Utilities/SZLog.swift
       - &archive_preview_shared_defaults_source
         path: ../../ShichiZip/Utilities/SZSharedUserDefaults.swift
-      - &archive_preview_localization_resources
-        path: ../../ShichiZip/Resources/Localization
-        buildPhase: resources
     dependencies: &archive_preview_dependencies
       - sdk: AppKit.framework
       - sdk: QuickLookUI.framework
       - sdk: UniformTypeIdentifiers.framework
+      - target: ShichiZipLocalization
       - target: ShichiZipArchiveCore
     settings:
       base:
@@ -161,11 +159,11 @@ targets:
       - *archive_preview_bridge_sources
       - *archive_preview_log_source
       - *archive_preview_shared_defaults_source
-      - *archive_preview_localization_resources
     dependencies:
       - sdk: AppKit.framework
       - sdk: QuickLookUI.framework
       - sdk: UniformTypeIdentifiers.framework
+      - target: ShichiZipLocalization
       - target: ShichiZipZSArchiveCore
     settings:
       base:


### PR DESCRIPTION
Add Xcode-managed ArchiveCore framework targets that force-load the Zig-built 7-Zip static archives, then link the app, Quick Look preview extension, and tests against the shared framework.