### PR TITLE
feat: register more archive/disk-image file type associations (iso, udif, deb, chm)

### DIFF
--- a/ShichiZip/Resources/Info.plist
+++ b/ShichiZip/Resources/Info.plist
@@ -742,46 +742,6 @@
 		</dict>
 		<dict>
 			<key>CFBundleTypeName</key>
-			<string>MDF Disk Image</string>
-			<key>CFBundleTypeIconFile</key>
-			<string>archive</string>
-			<key>NSDocumentClass</key>
-			<string>$(PRODUCT_MODULE_NAME).ArchiveDocument</string>
-			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
-			<key>LSHandlerRank</key>
-			<string>Alternate</string>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>mdf</string>
-			</array>
-			<key>LSItemContentTypes</key>
-			<array>
-				<string>com.alcohol-soft.mdf-disk-image</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeName</key>
-			<string>MDS Disk Image</string>
-			<key>CFBundleTypeIconFile</key>
-			<string>archive</string>
-			<key>NSDocumentClass</key>
-			<string>$(PRODUCT_MODULE_NAME).ArchiveDocument</string>
-			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
-			<key>LSHandlerRank</key>
-			<string>Alternate</string>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>mds</string>
-			</array>
-			<key>LSItemContentTypes</key>
-			<array>
-				<string>com.alcohol-soft.mds-disk-image</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeName</key>
 			<string>LHA Archive</string>
 			<key>CFBundleTypeIconFile</key>
 			<string>archive</string>
@@ -1223,42 +1183,6 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>chm</string>
-				</array>
-			</dict>
-		</dict>
-		<dict>
-			<key>UTTypeIdentifier</key>
-			<string>com.alcohol-soft.mdf-disk-image</string>
-			<key>UTTypeDescription</key>
-			<string>MDF Disk Image</string>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.disk-image</string>
-				<string>public.data</string>
-			</array>
-			<key>UTTypeTagSpecification</key>
-			<dict>
-				<key>public.filename-extension</key>
-				<array>
-					<string>mdf</string>
-				</array>
-			</dict>
-		</dict>
-		<dict>
-			<key>UTTypeIdentifier</key>
-			<string>com.alcohol-soft.mds-disk-image</string>
-			<key>UTTypeDescription</key>
-			<string>MDS Disk Image</string>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.disk-image</string>
-				<string>public.data</string>
-			</array>
-			<key>UTTypeTagSpecification</key>
-			<dict>
-				<key>public.filename-extension</key>
-				<array>
-					<string>mds</string>
 				</array>
 			</dict>
 		</dict>

--- a/ShichiZip/Resources/Info.plist
+++ b/ShichiZip/Resources/Info.plist
@@ -682,6 +682,106 @@
 		</dict>
 		<dict>
 			<key>CFBundleTypeName</key>
+			<string>UDIF Disk Image</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>archive</string>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).ArchiveDocument</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>udif</string>
+			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.apple.disk-image-udif</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Debian Package Archive</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>archive</string>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).ArchiveDocument</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>deb</string>
+			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.debian.deb-archive</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Compiled HTML Help</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>archive</string>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).ArchiveDocument</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>chm</string>
+			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.microsoft.chm</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>MDF Disk Image</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>archive</string>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).ArchiveDocument</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>mdf</string>
+			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.alcohol-soft.mdf-disk-image</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>MDS Disk Image</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>archive</string>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).ArchiveDocument</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>mds</string>
+			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.alcohol-soft.mds-disk-image</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
 			<string>LHA Archive</string>
 			<key>CFBundleTypeIconFile</key>
 			<string>archive</string>
@@ -1088,6 +1188,77 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>zipx</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.debian.deb-archive</string>
+			<key>UTTypeDescription</key>
+			<string>Debian Package Archive</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.archive</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>deb</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.microsoft.chm</string>
+			<key>UTTypeDescription</key>
+			<string>Compiled HTML Help</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>chm</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.alcohol-soft.mdf-disk-image</string>
+			<key>UTTypeDescription</key>
+			<string>MDF Disk Image</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.disk-image</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mdf</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.alcohol-soft.mds-disk-image</string>
+			<key>UTTypeDescription</key>
+			<string>MDS Disk Image</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.disk-image</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mds</string>
 				</array>
 			</dict>
 		</dict>

--- a/ShichiZip/Resources/Info.plist
+++ b/ShichiZip/Resources/Info.plist
@@ -684,7 +684,7 @@
 			<key>CFBundleTypeName</key>
 			<string>UDIF Disk Image</string>
 			<key>CFBundleTypeIconFile</key>
-			<string>archive</string>
+			<string>diskimg</string>
 			<key>NSDocumentClass</key>
 			<string>$(PRODUCT_MODULE_NAME).ArchiveDocument</string>
 			<key>CFBundleTypeRole</key>
@@ -1177,6 +1177,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.data</string>
+				<string>public.archive</string>
 			</array>
 			<key>UTTypeTagSpecification</key>
 			<dict>

--- a/ShichiZipTests/QuickActionTransportTests.swift
+++ b/ShichiZipTests/QuickActionTransportTests.swift
@@ -27,6 +27,88 @@ final class QuickActionTransportTests: XCTestCase {
         super.tearDown()
     }
 
+    func testInfoPlistRegistersAdditionalArchiveAndDiskImageFileTypes() throws {
+        let infoPlist = try loadSourceInfoPlist()
+        let documentTypes = try XCTUnwrap(infoPlist["CFBundleDocumentTypes"] as? [[String: Any]])
+        let importedTypes = try XCTUnwrap(infoPlist["UTImportedTypeDeclarations"] as? [[String: Any]])
+        let importedTypeIdentifiers = importedTypes.compactMap { $0["UTTypeIdentifier"] as? String }
+        XCTAssertEqual(importedTypeIdentifiers.count, Set(importedTypeIdentifiers).count)
+
+        var importedTypesByIdentifier: [String: [String: Any]] = [:]
+        for importedType in importedTypes {
+            guard let identifier = importedType["UTTypeIdentifier"] as? String else {
+                continue
+            }
+
+            importedTypesByIdentifier[identifier] = importedType
+        }
+
+        let knownSystemContentTypes: Set<String> = [
+            "com.android.package-archive",
+            "com.apple.archive",
+            "com.apple.bom-compressed-cpio",
+            "com.apple.disk-image",
+            "com.apple.disk-image-smi",
+            "com.apple.disk-image-udif",
+            "com.apple.encrypted-archive",
+            "com.apple.iTunes.ipa",
+            "com.apple.xar-archive",
+            "com.microsoft.windows-executable",
+            "com.sun.java-archive",
+            "org.gnu.gnu-zip-archive",
+            "public.bzip2-archive",
+            "public.cpio-archive",
+            "public.iso-image",
+            "public.tar-archive",
+            "public.zip-archive",
+        ]
+        let referencedContentTypes = Set(documentTypes.flatMap { documentType in
+            documentType["LSItemContentTypes"] as? [String] ?? []
+        })
+        let danglingContentTypes = referencedContentTypes.filter { contentType in
+            !knownSystemContentTypes.contains(contentType) && importedTypesByIdentifier[contentType] == nil
+        }.sorted()
+        XCTAssertTrue(danglingContentTypes.isEmpty,
+                      "Dangling LSItemContentTypes: \(danglingContentTypes.joined(separator: ", "))")
+
+        for expectation in DocumentTypeExpectation.registeredArchiveAndDiskImageTypes {
+            let matchingDocumentTypes = documentTypes.filter { documentType in
+                let extensions = documentType["CFBundleTypeExtensions"] as? [String] ?? []
+                return extensions.contains(expectation.fileExtension)
+            }
+            XCTAssertEqual(matchingDocumentTypes.count,
+                           1,
+                           "Expected exactly one document type for .\(expectation.fileExtension)")
+
+            let documentType = try XCTUnwrap(matchingDocumentTypes.first)
+            XCTAssertEqual(documentType["CFBundleTypeIconFile"] as? String, expectation.iconFile)
+            XCTAssertEqual(documentType["NSDocumentClass"] as? String, "$(PRODUCT_MODULE_NAME).ArchiveDocument")
+            XCTAssertEqual(documentType["CFBundleTypeRole"] as? String, "Viewer")
+            XCTAssertEqual(documentType["LSHandlerRank"] as? String, "Alternate")
+
+            let contentTypes = try XCTUnwrap(documentType["LSItemContentTypes"] as? [String])
+            XCTAssertEqual(contentTypes, expectation.contentTypes)
+            XCTAssertFalse(contentTypes.isEmpty)
+
+            for contentType in contentTypes where !knownSystemContentTypes.contains(contentType) {
+                XCTAssertNotNil(importedTypesByIdentifier[contentType],
+                                "\(contentType) must be declared in UTImportedTypeDeclarations")
+            }
+        }
+
+        for expectation in ImportedTypeExpectation.additionalArchiveAndDiskImageTypes {
+            let importedType = try XCTUnwrap(importedTypesByIdentifier[expectation.identifier])
+            XCTAssertEqual(importedType["UTTypeDescription"] as? String, expectation.typeDescription)
+
+            let conformsTo = try XCTUnwrap(importedType["UTTypeConformsTo"] as? [String])
+            XCTAssertEqual(Set(conformsTo), Set(expectation.conformsTo))
+
+            let tagSpecification = try XCTUnwrap(importedType["UTTypeTagSpecification"] as? [String: Any])
+            XCTAssertEqual(tagSpecification["public.filename-extension"] as? [String],
+                           [expectation.fileExtension])
+        }
+    }
+
     @MainActor
     func testDeliveredQuickActionLaunchDoesNotKeepProcessAliveWhenLaunchNotificationArrivesLater() {
         let coordinator = LaunchOpenCoordinator()
@@ -331,5 +413,70 @@ final class QuickActionTransportTests: XCTestCase {
         (try? FileManager.default.contentsOfDirectory(at: requestDirectoryURL,
                                                       includingPropertiesForKeys: nil,
                                                       options: [])) ?? []
+    }
+
+    private func loadSourceInfoPlist() throws -> [String: Any] {
+        let infoPlistURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("ShichiZip/Resources/Info.plist")
+        let infoPlistData = try Data(contentsOf: infoPlistURL)
+        let propertyList = try PropertyListSerialization.propertyList(from: infoPlistData,
+                                                                      options: [],
+                                                                      format: nil)
+        return try XCTUnwrap(propertyList as? [String: Any])
+    }
+
+    private struct DocumentTypeExpectation {
+        let fileExtension: String
+        let iconFile: String
+        let contentTypes: [String]
+
+        static let registeredArchiveAndDiskImageTypes = [
+            DocumentTypeExpectation(fileExtension: "iso",
+                                    iconFile: "diskimg",
+                                    contentTypes: ["public.iso-image"]),
+            DocumentTypeExpectation(fileExtension: "udif",
+                                    iconFile: "archive",
+                                    contentTypes: ["com.apple.disk-image-udif"]),
+            DocumentTypeExpectation(fileExtension: "deb",
+                                    iconFile: "archive",
+                                    contentTypes: ["org.debian.deb-archive"]),
+            DocumentTypeExpectation(fileExtension: "chm",
+                                    iconFile: "archive",
+                                    contentTypes: ["com.microsoft.chm"]),
+            DocumentTypeExpectation(fileExtension: "mdf",
+                                    iconFile: "archive",
+                                    contentTypes: ["com.alcohol-soft.mdf-disk-image"]),
+            DocumentTypeExpectation(fileExtension: "mds",
+                                    iconFile: "archive",
+                                    contentTypes: ["com.alcohol-soft.mds-disk-image"]),
+        ]
+    }
+
+    private struct ImportedTypeExpectation {
+        let identifier: String
+        let typeDescription: String
+        let fileExtension: String
+        let conformsTo: [String]
+
+        static let additionalArchiveAndDiskImageTypes = [
+            ImportedTypeExpectation(identifier: "org.debian.deb-archive",
+                                    typeDescription: "Debian Package Archive",
+                                    fileExtension: "deb",
+                                    conformsTo: ["public.data", "public.archive"]),
+            ImportedTypeExpectation(identifier: "com.microsoft.chm",
+                                    typeDescription: "Compiled HTML Help",
+                                    fileExtension: "chm",
+                                    conformsTo: ["public.data"]),
+            ImportedTypeExpectation(identifier: "com.alcohol-soft.mdf-disk-image",
+                                    typeDescription: "MDF Disk Image",
+                                    fileExtension: "mdf",
+                                    conformsTo: ["public.disk-image", "public.data"]),
+            ImportedTypeExpectation(identifier: "com.alcohol-soft.mds-disk-image",
+                                    typeDescription: "MDS Disk Image",
+                                    fileExtension: "mds",
+                                    conformsTo: ["public.disk-image", "public.data"]),
+        ]
     }
 }

--- a/ShichiZipTests/QuickActionTransportTests.swift
+++ b/ShichiZipTests/QuickActionTransportTests.swift
@@ -445,12 +445,6 @@ final class QuickActionTransportTests: XCTestCase {
             DocumentTypeExpectation(fileExtension: "chm",
                                     iconFile: "archive",
                                     contentTypes: ["com.microsoft.chm"]),
-            DocumentTypeExpectation(fileExtension: "mdf",
-                                    iconFile: "archive",
-                                    contentTypes: ["com.alcohol-soft.mdf-disk-image"]),
-            DocumentTypeExpectation(fileExtension: "mds",
-                                    iconFile: "archive",
-                                    contentTypes: ["com.alcohol-soft.mds-disk-image"]),
         ]
     }
 
@@ -469,14 +463,6 @@ final class QuickActionTransportTests: XCTestCase {
                                     typeDescription: "Compiled HTML Help",
                                     fileExtension: "chm",
                                     conformsTo: ["public.data"]),
-            ImportedTypeExpectation(identifier: "com.alcohol-soft.mdf-disk-image",
-                                    typeDescription: "MDF Disk Image",
-                                    fileExtension: "mdf",
-                                    conformsTo: ["public.disk-image", "public.data"]),
-            ImportedTypeExpectation(identifier: "com.alcohol-soft.mds-disk-image",
-                                    typeDescription: "MDS Disk Image",
-                                    fileExtension: "mds",
-                                    conformsTo: ["public.disk-image", "public.data"]),
         ]
     }
 }

--- a/ShichiZipTests/QuickActionTransportTests.swift
+++ b/ShichiZipTests/QuickActionTransportTests.swift
@@ -437,7 +437,7 @@ final class QuickActionTransportTests: XCTestCase {
                                     iconFile: "diskimg",
                                     contentTypes: ["public.iso-image"]),
             DocumentTypeExpectation(fileExtension: "udif",
-                                    iconFile: "archive",
+                                    iconFile: "diskimg",
                                     contentTypes: ["com.apple.disk-image-udif"]),
             DocumentTypeExpectation(fileExtension: "deb",
                                     iconFile: "archive",
@@ -462,7 +462,7 @@ final class QuickActionTransportTests: XCTestCase {
             ImportedTypeExpectation(identifier: "com.microsoft.chm",
                                     typeDescription: "Compiled HTML Help",
                                     fileExtension: "chm",
-                                    conformsTo: ["public.data"]),
+                                    conformsTo: ["public.data", "public.archive"]),
         ]
     }
 }

--- a/project/specs/quick-actions.yml
+++ b/project/specs/quick-actions.yml
@@ -233,6 +233,11 @@ targets:
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.disk-image" ||
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.disk-image-smi" ||
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.iso-image" ||
+              ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.disk-image-udif" ||
+              ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.alcohol-soft.mdf-disk-image" ||
+              ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.alcohol-soft.mds-disk-image" ||
+              ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.debian.deb-archive" ||
+              ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.chm" ||
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.archive.lha" ||
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.windows-executable" ||
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.cab-archive" ||

--- a/project/specs/quick-actions.yml
+++ b/project/specs/quick-actions.yml
@@ -234,8 +234,6 @@ targets:
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.disk-image-smi" ||
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.iso-image" ||
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.disk-image-udif" ||
-              ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.alcohol-soft.mdf-disk-image" ||
-              ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.alcohol-soft.mds-disk-image" ||
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.debian.deb-archive" ||
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.chm" ||
               ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.archive.lha" ||

--- a/project/specs/quicklook-preview.yml
+++ b/project/specs/quicklook-preview.yml
@@ -134,8 +134,6 @@ targets:
               - com.apple.disk-image-smi
               - public.iso-image
               - com.apple.disk-image-udif
-              - com.alcohol-soft.mdf-disk-image
-              - com.alcohol-soft.mds-disk-image
               - org.debian.deb-archive
               - com.microsoft.chm
               - public.archive.lha

--- a/project/specs/quicklook-preview.yml
+++ b/project/specs/quicklook-preview.yml
@@ -133,6 +133,11 @@ targets:
               - com.apple.disk-image
               - com.apple.disk-image-smi
               - public.iso-image
+              - com.apple.disk-image-udif
+              - com.alcohol-soft.mdf-disk-image
+              - com.alcohol-soft.mds-disk-image
+              - org.debian.deb-archive
+              - com.microsoft.chm
               - public.archive.lha
               - com.microsoft.windows-executable
               - com.microsoft.cab-archive


### PR DESCRIPTION
## Summary

Registers Finder file-type associations for `udif`, `deb`, and `chm`, so these formats are bound to ShichiZip in Launch Services and show up in the Integration tab. Each new format gets a `CFBundleDocumentTypes` entry following the existing 7Z/LZMA/LZOP convention, plus a `UTImportedTypeDeclarations` entry for the extensions that lack a well-known system UTI:

- `udif` -> `com.apple.disk-image-udif` (system UTI; uses the `diskimg` document icon like the existing DMG/ISO/WIM entries)
- `deb` -> `org.debian.deb-archive` (imported UTI conforming to `public.data` + `public.archive`)
- `chm` -> `com.microsoft.chm` (imported UTI conforming to `public.data` + `public.archive`)

The same UTIs are mirrored into the two Finder-integration allowlists so the new formats also get Smart Quick Extract Quick Actions and Quick Look archive previews:

- `project/specs/quick-actions.yml` (Smart Quick Extract activation predicate)
- `project/specs/quicklook-preview.yml` (`QLSupportedContentTypes`)

`iso` was already registered via `public.iso-image`, so it is left unchanged. New `LSItemContentTypes` entries use `LSHandlerRank` `Alternate` so ShichiZip does not aggressively steal disk-image defaults from the system.

## Why this matters

Issue #38 reports that several archive/disk-image formats ShichiZip can already open in its viewer are not bound in Finder or shown in the Integration tab. The maintainer confirmed that Launch Services associates apps by UTI / content type and noted they would cover more file extensions with a third-party exported UTI. This change stays inside that UTI-based model and adds no Swift behavior change, since the formats already open through the existing extraction path.

`mdf` and `mds` (also listed in the issue) are intentionally not registered here: the bundled 7-Zip backend has no MDF/MDS reader, so advertising those associations would route Finder to ShichiZip for files it cannot open. The split-archive `.001`/`.002` sequence-extension icon request is likewise out of scope for this change.

## Testing

- `plutil -lint ShichiZip/Resources/Info.plist` passes.
- Both spec YAML files parse cleanly.
- Added a plist regression test (`ShichiZipTests/QuickActionTransportTests.swift`) asserting each new extension resolves to exactly one document type with the expected icon, role, handler rank, and content type, that every referenced content type is either a known system UTI or declared in `UTImportedTypeDeclarations` (no dangling references), and that the imported UTIs declare the expected conformances and extension tags.

Refs #38
