### PR TITLE
feat: gate status-bar size summary by directory vs archive context

### DIFF
--- a/ShichiZip/Dialogs/SettingsWindowController.swift
+++ b/ShichiZip/Dialogs/SettingsWindowController.swift
@@ -213,6 +213,33 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate, NSTableVie
         resetFileListPreferencesNote.preferredMaxLayoutWidth = 480
         stack.addArrangedSubview(resetFileListPreferencesNote)
 
+        let statusBarSizeRow = NSStackView()
+        statusBarSizeRow.orientation = .horizontal
+        statusBarSizeRow.alignment = .centerY
+        statusBarSizeRow.spacing = 8
+
+        let statusBarSizeLabel = NSTextField(labelWithString: SZL10n.string("app.settings.statusBarSize"))
+        statusBarSizeRow.addArrangedSubview(statusBarSizeLabel)
+
+        let statusBarSizePopup = NSPopUpButton()
+        let statusBarSizeItems: [(String, Int)] = [
+            (SZL10n.string("app.settings.statusBarSize.always"), 0),
+            (SZL10n.string("app.settings.statusBarSize.archiveOnly"), 1),
+        ]
+        for item in statusBarSizeItems {
+            statusBarSizePopup.addItem(withTitle: item.0)
+            statusBarSizePopup.lastItem?.tag = item.1
+        }
+        if let item = statusBarSizePopup.itemArray.first(where: { $0.tag == SZSettings.statusBarSizeMode }) {
+            statusBarSizePopup.select(item)
+        }
+        statusBarSizePopup.target = self
+        statusBarSizePopup.action = #selector(statusBarSizeModeChanged(_:))
+        statusBarSizePopup.setAccessibilityIdentifier("settings.statusBarSizeMode")
+        statusBarSizeRow.addArrangedSubview(statusBarSizePopup)
+
+        stack.addArrangedSubview(statusBarSizeRow)
+
         let compressionSeparator = makeSettingsSeparator()
         stack.addArrangedSubview(compressionSeparator)
         compressionSeparator.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
@@ -1028,6 +1055,10 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate, NSTableVie
 
     @objc private func memLimitChanged(_ sender: NSTextField) {
         SZSettings.set(max(1, sender.integerValue), for: .memLimitGB)
+    }
+
+    @objc private func statusBarSizeModeChanged(_ sender: NSPopUpButton) {
+        SZSettings.set(sender.selectedItem?.tag ?? 0, for: .statusBarSizeMode)
     }
 
     @objc private func launchOpenActionChanged(_ sender: NSButton) {

--- a/ShichiZip/FileManager/Pane/FileManagerItemPresentation.swift
+++ b/ShichiZip/FileManager/Pane/FileManagerItemPresentation.swift
@@ -42,9 +42,12 @@ enum FileManagerItemPresentation {
     }
 
     static func statusBarText(displayed: FileManagerItemStatusSummary,
-                              selected: FileManagerItemStatusSummary?) -> String
+                              selected: FileManagerItemStatusSummary?,
+                              sizeMode: Int = 0,
+                              isInsideArchive: Bool = false) -> String
     {
-        let displayedSummaryText = summaryText(displayed)
+        let includeSize = !(sizeMode == 1 && !isInsideArchive)
+        let displayedSummaryText = summaryText(displayed, includeSize: includeSize)
         guard let selected, !selected.isEmpty else {
             return displayedSummaryText
         }
@@ -300,10 +303,13 @@ enum FileManagerItemPresentation {
                                             folderSize: folderSize)
     }
 
-    private static func summaryText(_ summary: FileManagerItemStatusSummary) -> String {
+    private static func summaryText(_ summary: FileManagerItemStatusSummary, includeSize: Bool = true) -> String {
         let sizeString = fileSizeString(summary.totalSize)
         let fileWord = summary.fileCount == 1 ? SZL10n.string("app.fileManager.statusFile") : SZL10n.string("app.fileManager.statusFiles")
         let folderWord = summary.folderCount == 1 ? SZL10n.string("app.fileManager.statusFolder") : SZL10n.string("app.fileManager.statusFolders")
+        guard includeSize else {
+            return "\(summary.fileCount) \(fileWord), \(summary.folderCount) \(folderWord)"
+        }
         return "\(summary.fileCount) \(fileWord), \(summary.folderCount) \(folderWord) — \(sizeString)"
     }
 

--- a/ShichiZip/FileManager/Pane/FileManagerPaneController.swift
+++ b/ShichiZip/FileManager/Pane/FileManagerPaneController.swift
@@ -1110,7 +1110,9 @@ class FileManagerPaneController: NSViewController, NSTableViewDataSource, NSTabl
         }
 
         statusLabel.stringValue = FileManagerItemPresentation.statusBarText(displayed: displayedSummary,
-                                                                            selected: selectedSummary)
+                                                                            selected: selectedSummary,
+                                                                            sizeMode: SZSettings.statusBarSizeMode,
+                                                                            isInsideArchive: isInsideArchive)
     }
 
     // MARK: - Settings
@@ -1147,6 +1149,9 @@ class FileManagerPaneController: NSViewController, NSTableViewDataSource, NSTabl
             return
         case .fileManagerShortcutPreset, .fileManagerCustomShortcuts:
             refreshContextMenu()
+            return
+        case .statusBarSizeMode:
+            updateStatusBar()
             return
         default:
             return

--- a/ShichiZip/Resources/Localization/en.lproj/App.strings
+++ b/ShichiZip/Resources/Localization/en.lproj/App.strings
@@ -213,6 +213,9 @@
 "app.settings.resetFileListLayoutNote" = "Clears saved sort order, column order, and column widths for File Manager lists.";
 "app.settings.resetFileManagerWindowFrame" = "Reset Saved Window Size and Position";
 "app.settings.scheme" = "Scheme:";
+"app.settings.statusBarSize" = "Status bar size:";
+"app.settings.statusBarSize.always" = "Always show total size";
+"app.settings.statusBarSize.archiveOnly" = "Only inside archives";
 "app.settings.setAllAsDefault" = "Set All as Default";
 "app.settings.shortcuts" = "Shortcuts";
 "app.settings.shortcutsCustomNote" = "Changing an individual binding switches the preset to Custom. Reusing a shortcut clears it from the previous command. Click a shortcut field and press any key combination. Press Escape to cancel recording.";

--- a/ShichiZip/Resources/Localization/zh-Hans.lproj/App.strings
+++ b/ShichiZip/Resources/Localization/zh-Hans.lproj/App.strings
@@ -213,6 +213,9 @@
 "app.settings.resetFileListLayoutNote" = "清除文件管理器列表已保存的排序、列顺序和列宽。";
 "app.settings.resetFileManagerWindowFrame" = "重置已保存的窗口大小和位置";
 "app.settings.scheme" = "方案：";
+"app.settings.statusBarSize" = "状态栏大小：";
+"app.settings.statusBarSize.always" = "始终显示总大小";
+"app.settings.statusBarSize.archiveOnly" = "仅在压缩包内显示";
 "app.settings.setAllAsDefault" = "全部设为默认";
 "app.settings.shortcuts" = "快捷键";
 "app.settings.shortcutsCustomNote" = "修改单个快捷键后方案将切换为「自定义」。重复使用的快捷键会从原命令中清除。点击快捷键区域后按下任意组合键。按 Esc 取消录制。";

--- a/ShichiZip/Resources/Localization/zh-Hant.lproj/App.strings
+++ b/ShichiZip/Resources/Localization/zh-Hant.lproj/App.strings
@@ -213,6 +213,9 @@
 "app.settings.resetFileListLayoutNote" = "清除檔案管理器列表已儲存的排序方式、欄位順序與欄寬。";
 "app.settings.resetFileManagerWindowFrame" = "重設已儲存的視窗大小與位置";
 "app.settings.scheme" = "設定檔：";
+"app.settings.statusBarSize" = "狀態列大小：";
+"app.settings.statusBarSize.always" = "一律顯示總大小";
+"app.settings.statusBarSize.archiveOnly" = "僅在壓縮檔內顯示";
 "app.settings.setAllAsDefault" = "全部設為預設";
 "app.settings.shortcuts" = "快速鍵";
 "app.settings.shortcutsCustomNote" = "變更個別綁定會將預設組合切換為自訂。重複使用快速鍵會將它從先前的指令清除。按一下快速鍵欄位並按下任意按鍵組合。按 Escape 可取消錄製。";

--- a/ShichiZip/Utilities/SZSettings.swift
+++ b/ShichiZip/Utilities/SZSettings.swift
@@ -21,6 +21,7 @@ enum SZSettingsKey: String {
     case inheritDownloadedFileQuarantine = "InheritDownloadedFileQuarantine"
     case memLimitEnabled = "MemLimitEnabled"
     case memLimitGB = "MemLimitGB"
+    case statusBarSizeMode = "StatusBarSizeMode"
 
     // Shortcuts page
     case fileManagerShortcutPreset = "FileManagerShortcutPreset"
@@ -147,6 +148,10 @@ enum SZSettings {
     static var memLimitGB: Int {
         let v = defaults.integer(forKey: SZSettingsKey.memLimitGB.rawValue)
         return v > 0 ? v : 4
+    }
+
+    static var statusBarSizeMode: Int {
+        integer(.statusBarSizeMode)
     }
 
     static var quickLookPreviewExpansionDepth: Int {

--- a/ShichiZipTests/ArchivePreviewPresentationTests.swift
+++ b/ShichiZipTests/ArchivePreviewPresentationTests.swift
@@ -43,6 +43,88 @@ final class ArchivePreviewPresentationTests: XCTestCase {
                        "2 \(ArchivePreviewLocalization.string("app.fileManager.statusFiles")), 1 \(ArchivePreviewLocalization.string("app.fileManager.statusFolder")) — \(ByteCountFormatter.string(fromByteCount: 7, countStyle: .file))")
     }
 
+    func testStatusBarArchiveOnlyModeOmitsDisplayedSizeOutsideArchives() {
+        let summary = makeStatusSummary(fileCount: 2,
+                                        folderCount: 1,
+                                        fileSize: 42)
+
+        let text = FileManagerItemPresentation.statusBarText(displayed: summary,
+                                                             selected: nil,
+                                                             sizeMode: 1,
+                                                             isInsideArchive: false)
+
+        XCTAssertTrue(text.contains("2 \(SZL10n.string("app.fileManager.statusFiles"))"))
+        XCTAssertTrue(text.contains("1 \(SZL10n.string("app.fileManager.statusFolder"))"))
+        XCTAssertFalse(text.contains(statusSizeString(42)))
+    }
+
+    func testStatusBarArchiveOnlyModeShowsDisplayedSizeInsideArchives() {
+        let summary = makeStatusSummary(fileCount: 2,
+                                        folderCount: 1,
+                                        fileSize: 42)
+
+        let text = FileManagerItemPresentation.statusBarText(displayed: summary,
+                                                             selected: nil,
+                                                             sizeMode: 1,
+                                                             isInsideArchive: true)
+
+        XCTAssertTrue(text.contains(statusSizeString(42)))
+    }
+
+    func testStatusBarDefaultModeShowsDisplayedSizeInBothContexts() {
+        let summary = makeStatusSummary(fileCount: 2,
+                                        folderCount: 1,
+                                        fileSize: 42)
+        let defaultText = FileManagerItemPresentation.statusBarText(displayed: summary,
+                                                                    selected: nil)
+        let folderText = FileManagerItemPresentation.statusBarText(displayed: summary,
+                                                                   selected: nil,
+                                                                   sizeMode: 0,
+                                                                   isInsideArchive: false)
+        let archiveText = FileManagerItemPresentation.statusBarText(displayed: summary,
+                                                                    selected: nil,
+                                                                    sizeMode: 0,
+                                                                    isInsideArchive: true)
+
+        XCTAssertEqual(folderText, defaultText)
+        XCTAssertEqual(archiveText, defaultText)
+        XCTAssertTrue(folderText.contains(statusSizeString(42)))
+        XCTAssertTrue(archiveText.contains(statusSizeString(42)))
+    }
+
+    func testStatusBarArchiveOnlyModeKeepsSelectionSizeOutsideArchives() {
+        let displayed = makeStatusSummary(fileCount: 3,
+                                          folderCount: 1,
+                                          fileSize: 4_096)
+        let selected = makeStatusSummary(fileCount: 1,
+                                         folderCount: 0,
+                                         fileSize: 123)
+
+        let text = FileManagerItemPresentation.statusBarText(displayed: displayed,
+                                                             selected: selected,
+                                                             sizeMode: 1,
+                                                             isInsideArchive: false)
+
+        XCTAssertFalse(text.contains(statusSizeString(4_096)))
+        XCTAssertTrue(text.contains(statusSizeString(123)))
+    }
+
+    func testStatusBarEmptySummariesRenderUnderBothModes() {
+        let empty = makeStatusSummary()
+
+        for sizeMode in [0, 1] {
+            for isInsideArchive in [false, true] {
+                let text = FileManagerItemPresentation.statusBarText(displayed: empty,
+                                                                     selected: nil,
+                                                                     sizeMode: sizeMode,
+                                                                     isInsideArchive: isInsideArchive)
+
+                XCTAssertTrue(text.contains("0 \(SZL10n.string("app.fileManager.statusFiles"))"))
+                XCTAssertTrue(text.contains("0 \(SZL10n.string("app.fileManager.statusFolders"))"))
+            }
+        }
+    }
+
     func testArchiveColumnsUseMainAppArchiveDefaults() {
         let columns = ArchivePreviewColumn.archiveColumns(entryProperties: [
             ArchivePreviewEntryProperty(id: .size,
@@ -192,5 +274,20 @@ final class ArchivePreviewPresentationTests: XCTestCase {
                     position: 0,
                     block: 0,
                     comment: "")
+    }
+
+    private func makeStatusSummary(fileCount: Int = 0,
+                                   folderCount: Int = 0,
+                                   fileSize: UInt64 = 0,
+                                   folderSize: UInt64 = 0) -> FileManagerItemStatusSummary
+    {
+        FileManagerItemStatusSummary(fileCount: fileCount,
+                                     folderCount: folderCount,
+                                     fileSize: fileSize,
+                                     folderSize: folderSize)
+    }
+
+    private func statusSizeString(_ size: UInt64) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(clamping: size), countStyle: .file)
     }
 }


### PR DESCRIPTION
## Summary
Adds a "Status bar size" preference so the file-manager status bar can show the total-size token only when inside an archive. The new `statusBarSizeMode` (0 = always show total size, today's default; 1 = only inside archives) gates the displayed/total summary's size token without changing any size computation, so there is zero added I/O.

## Why this matters
As raised in #43, the status bar's directory total only sums the files directly in the current folder, which is misleading for a plain directory yet not a true recursive total. The maintainer noted that recursive totals are I/O-costly, so this ships the I/O-safe subset: a user preference that simply hides the size for plain directories while still surfacing the uncompressed total when browsing inside an archive (matching the Quick Look behavior the reporter wanted). The recursive-subfolder option is intentionally omitted because of the stated I/O cost.

Behavior details:
- Mode 0 (default) is byte-identical to current behavior in both directory and archive contexts.
- Mode 1 omits the size token from the displayed/total summary only when not inside an archive; inside an archive the size is still shown.
- Selection summaries always show their size regardless of mode.

## Testing
- Added focused unit tests in `ArchivePreviewPresentationTests` covering: archive-only mode outside an archive (size omitted, counts kept), archive-only mode inside an archive (size shown), default mode parity, selection summary always retaining its size, and empty directory/archive rendering under both modes.
- Verified all changed Swift sources parse with `swiftc -parse` and the three `App.strings` files pass `plutil -lint`. The full app build (`zig build lib` + `xcodebuild`) requires the native 7zip toolchain step and was not run to completion in this environment; the change is confined to the Swift presentation/settings layer and localized strings.

Fixes #43
