### PR TITLE
Add Finder reveal preferences for file manager and transfer dialogs

### DIFF
--- a/ShichiZip/App/AppDelegate.swift
+++ b/ShichiZip/App/AppDelegate.swift
@@ -50,7 +50,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, FileManagerDocumentOpenRouti
     }
 
     func applicationWillFinishLaunching(_: Notification) {
-        SZSharedUserDefaults.migrateStandardDefaultsIfNeeded()
+        SZSettingsMigrations.preparePreferences()
         let documentController = ShichiZipDocumentController()
         precondition(NSDocumentController.shared === documentController,
                      "ShichiZipDocumentController must be the shared document controller")

--- a/ShichiZip/App/LaunchOpenHUDController.swift
+++ b/ShichiZip/App/LaunchOpenHUDController.swift
@@ -107,7 +107,7 @@ final class LaunchOpenHUDController: NSObject {
     private var urls: [URL]
     private let totalSeconds: TimeInterval
     private let browseModifier: LaunchOpenBrowseModifier
-    private let revealAfterExtract: Bool
+    private let RevealAfterLaunchOpenExtract: Bool
     private var panel: NSPanel?
     private var titleLabel: NSTextField?
     private var countdownLabel: NSTextField?
@@ -124,7 +124,7 @@ final class LaunchOpenHUDController: NSObject {
         self.urls = urls
         totalSeconds = seconds
         browseModifier = SZSettings.launchOpenBrowseModifier
-        revealAfterExtract = SZSettings.launchOpenRevealAfterExtract
+        RevealAfterLaunchOpenExtract = SZSettings.launchOpenRevealAfterExtract
         super.init()
     }
 
@@ -486,7 +486,7 @@ final class LaunchOpenHUDController: NSObject {
                 }
             case .extract:
                 Self.runSmartExtract(urls: pendingURLs,
-                                     revealDestination: revealAfterExtract)
+                                     revealDestination: RevealAfterLaunchOpenExtract)
                 {
                     for r in releases {
                         r()

--- a/ShichiZip/App/LaunchOpenHUDController.swift
+++ b/ShichiZip/App/LaunchOpenHUDController.swift
@@ -107,7 +107,7 @@ final class LaunchOpenHUDController: NSObject {
     private var urls: [URL]
     private let totalSeconds: TimeInterval
     private let browseModifier: LaunchOpenBrowseModifier
-    private let RevealAfterLaunchOpenExtract: Bool
+    private let revealAfterLaunchOpenExtract: Bool
     private var panel: NSPanel?
     private var titleLabel: NSTextField?
     private var countdownLabel: NSTextField?
@@ -124,7 +124,7 @@ final class LaunchOpenHUDController: NSObject {
         self.urls = urls
         totalSeconds = seconds
         browseModifier = SZSettings.launchOpenBrowseModifier
-        RevealAfterLaunchOpenExtract = SZSettings.launchOpenRevealAfterExtract
+        revealAfterLaunchOpenExtract = SZSettings.launchOpenRevealAfterExtract
         super.init()
     }
 
@@ -486,7 +486,7 @@ final class LaunchOpenHUDController: NSObject {
                 }
             case .extract:
                 Self.runSmartExtract(urls: pendingURLs,
-                                     revealDestination: RevealAfterLaunchOpenExtract)
+                                     revealDestination: revealAfterLaunchOpenExtract)
                 {
                     for r in releases {
                         r()

--- a/ShichiZip/Bridge/SZArchive.h
+++ b/ShichiZip/Bridge/SZArchive.h
@@ -386,6 +386,14 @@ typedef NS_ENUM(NSInteger, SZCompressionTimePrecision) {
                session:(nullable SZOperationSession*)session
                  error:(NSError**)error;
 
+/// Extract entries and return their filesystem URLs after overwrite and rename handling.
+- (nullable NSArray<NSURL*>*)extractEntriesWithOutputURLs:(NSArray<NSNumber*>*)indices
+                                                   toPath:(NSString*)destinationPath
+                                                 settings:(SZExtractionSettings*)settings
+                                                  session:(nullable SZOperationSession*)session
+                                                    error:(NSError**)error
+    NS_SWIFT_NAME(extractEntriesWithOutputURLs(_:toPath:settings:session:));
+
 /// Test archive integrity with an explicit operation session
 - (BOOL)testWithSession:(nullable SZOperationSession*)session
                   error:(NSError**)error;

--- a/ShichiZip/Bridge/SZArchive.mm
+++ b/ShichiZip/Bridge/SZArchive.mm
@@ -1111,6 +1111,13 @@ static UInt32 SZCompressionEstimateAutoThreads(SZCompressionSettings* settings,
     BOOL _cachedPasswordIsDefined;
     NSUUID* _entrySnapshotIdentifier;
 }
+
+- (BOOL)extractEntries:(NSArray<NSNumber*>*)indices
+                toPath:(NSString*)destinationPath
+              settings:(SZExtractionSettings*)settings
+               session:(SZOperationSession*)session
+           outputPaths:(FStringVector*)outputPaths
+                 error:(NSError**)error;
 @end
 
 struct SZEntryPropertyMetadata {
@@ -2631,6 +2638,42 @@ static HRESULT SZExtractAndFinalize(IInArchive* archive,
               settings:(SZExtractionSettings*)s
                session:(SZOperationSession*)session
                  error:(NSError**)error {
+    return [self extractEntries:indices
+                         toPath:dest
+                       settings:s
+                        session:session
+                    outputPaths:NULL
+                          error:error];
+}
+
+- (NSArray<NSURL*>*)extractEntriesWithOutputURLs:(NSArray<NSNumber*>*)indices
+                                          toPath:(NSString*)dest
+                                        settings:(SZExtractionSettings*)s
+                                         session:(SZOperationSession*)session
+                                           error:(NSError**)error {
+    FStringVector outputPaths;
+    if (![self extractEntries:indices
+                       toPath:dest
+                     settings:s
+                      session:session
+                  outputPaths:&outputPaths
+                        error:error]) {
+        return nil;
+    }
+
+    NSMutableArray<NSURL*>* urls = [NSMutableArray arrayWithCapacity:outputPaths.Size()];
+    FOR_VECTOR(i, outputPaths) {
+        [urls addObject:[NSURL fileURLWithPath:ToNS(fs2us(outputPaths[i]))]];
+    }
+    return [urls copy];
+}
+
+- (BOOL)extractEntries:(NSArray<NSNumber*>*)indices
+                toPath:(NSString*)dest
+              settings:(SZExtractionSettings*)s
+               session:(SZOperationSession*)session
+           outputPaths:(FStringVector*)outputPaths
+                 error:(NSError**)error {
     SZArchiveOperationGuard operationGuard(self);
 
     if (!_isOpen) {
@@ -2669,6 +2712,7 @@ static HRESULT SZExtractAndFinalize(IInArchive* archive,
     }
     ecs->Init(ntOptions, NULL, &arc, faeCallback, false, false, us2fs(ToU(dest)),
         removePathParts, false, arc.GetEstmatedPhySize());
+    ecs->ExtractedPaths = outputPaths;
 
     std::vector<UInt32> ia;
     ia.reserve(indices.count);

--- a/ShichiZip/Dialogs/ExtractDialogContentController.swift
+++ b/ShichiZip/Dialogs/ExtractDialogContentController.swift
@@ -17,6 +17,7 @@ struct ExtractDialogState: Equatable {
     var showPassword: Bool
     var moveArchiveToTrashAfterExtraction: Bool
     var inheritDownloadedFileQuarantine: Bool
+    var revealAfterExtractInFileManager: Bool
 }
 
 struct ExtractDialogResolvedResult {
@@ -43,7 +44,8 @@ struct ExtractDialogResultBuilder {
                                          preserveNtSecurityInfo: state.preserveNtSecurityInfo,
                                          eliminateDuplicates: state.eliminateDuplicates,
                                          moveArchiveToTrashAfterExtraction: state.moveArchiveToTrashAfterExtraction,
-                                         inheritDownloadedFileQuarantine: state.inheritDownloadedFileQuarantine)
+                                         inheritDownloadedFileQuarantine: state.inheritDownloadedFileQuarantine,
+                                         revealAfterExtractInFileManager: state.revealAfterExtractInFileManager)
         return ExtractDialogResolvedResult(baseDestinationURL: baseDestinationURL,
                                            result: result)
     }
@@ -168,6 +170,7 @@ final class ExtractDialogContentController: NSObject {
     private let eliminateDuplicatesCheckbox = NSButton(checkboxWithTitle: SZL10n.string("extract.eliminateDuplication"), target: nil, action: nil)
     private let moveArchiveToTrashCheckbox = NSButton(checkboxWithTitle: SZL10n.string("app.extract.moveToTrash"), target: nil, action: nil)
     private let inheritDownloadedFileQuarantineCheckbox = NSButton(checkboxWithTitle: SZL10n.string("app.extract.inheritQuarantine"), target: nil, action: nil)
+    private let revealAfterExtractInFileManagerCheckbox = NSButton(checkboxWithTitle: SZL10n.string("app.fileManager.revealAfterExtract"), target: nil, action: nil)
     private var destinationPicker: DestinationPicker?
 
     private(set) var view = NSView()
@@ -225,6 +228,7 @@ final class ExtractDialogContentController: NSObject {
         state.eliminateDuplicates = eliminateDuplicatesCheckbox.state == .on
         state.moveArchiveToTrashAfterExtraction = moveArchiveToTrashCheckbox.state == .on
         state.inheritDownloadedFileQuarantine = inheritDownloadedFileQuarantineCheckbox.state == .on
+        state.revealAfterExtractInFileManager = revealAfterExtractInFileManagerCheckbox.state == .on
     }
 
     private func configureControls(destinationHistoryEntries: [String]) {
@@ -295,6 +299,9 @@ final class ExtractDialogContentController: NSObject {
         inheritDownloadedFileQuarantineCheckbox.isEnabled = sourceArchiveAvailableForQuarantineInheritance
         inheritDownloadedFileQuarantineCheckbox.alphaValue = sourceArchiveAvailableForQuarantineInheritance ? 1.0 : 0.55
         inheritDownloadedFileQuarantineCheckbox.setAccessibilityIdentifier("extract.inheritQuarantine")
+
+        revealAfterExtractInFileManagerCheckbox.state = state.revealAfterExtractInFileManager ? .on : .off
+        revealAfterExtractInFileManagerCheckbox.setAccessibilityIdentifier("extract.revealInFinder")
     }
 
     private func makeAccessoryView() -> NSView {
@@ -334,6 +341,7 @@ final class ExtractDialogContentController: NSObject {
         optionsLabel.font = .systemFont(ofSize: 12, weight: .semibold)
 
         let optionsStack = NSStackView(views: [
+            revealAfterExtractInFileManagerCheckbox,
             moveArchiveToTrashCheckbox,
             inheritDownloadedFileQuarantineCheckbox,
             ntSecurityCheckbox,

--- a/ShichiZip/Dialogs/ExtractDialogController.swift
+++ b/ShichiZip/Dialogs/ExtractDialogController.swift
@@ -9,6 +9,7 @@ struct ExtractDialogResult {
     let eliminateDuplicates: Bool
     let moveArchiveToTrashAfterExtraction: Bool
     let inheritDownloadedFileQuarantine: Bool
+    let revealAfterExtractInFileManager: Bool
 }
 
 struct ExtractQuickActionDefaults {
@@ -168,7 +169,8 @@ final class ExtractDialogController: NSObject {
                                               splitName: suggestedSplitDestinationName ?? "",
                                               showPassword: DialogPreferences.showPassword(),
                                               moveArchiveToTrashAfterExtraction: SZSettings.bool(.moveArchiveToTrashAfterExtraction),
-                                              inheritDownloadedFileQuarantine: SZSettings.bool(.inheritDownloadedFileQuarantine))
+                                              inheritDownloadedFileQuarantine: SZSettings.bool(.inheritDownloadedFileQuarantine),
+                                              revealAfterExtractInFileManager: SZSettings.revealAfterExtractInFileManager)
         let contentController = ExtractDialogContentController(state: initialState,
                                                                pathModeOptions: pathModeOptions,
                                                                overwriteModeOptions: overwriteModeOptions,
@@ -225,6 +227,7 @@ final class ExtractDialogController: NSObject {
                                  showPassword: state.showPassword)
         SZSettings.set(state.moveArchiveToTrashAfterExtraction, for: .moveArchiveToTrashAfterExtraction)
         SZSettings.set(state.inheritDownloadedFileQuarantine, for: .inheritDownloadedFileQuarantine)
+        SZSettings.revealAfterExtractInFileManager = state.revealAfterExtractInFileManager
         return resolvedResult.result
     }
 

--- a/ShichiZip/FileManager/Archive/FileManagerArchiveExtraction.swift
+++ b/ShichiZip/FileManager/Archive/FileManagerArchiveExtraction.swift
@@ -56,6 +56,20 @@ struct FileManagerExtractionMaterialization: @unchecked Sendable {
                                         withIntermediateDirectories: false)
     }
 
+    func publishedURL(for stagedURL: URL) throws -> URL {
+        let rootComponents = publishRootURL.standardizedFileURL.pathComponents
+        let outputComponents = stagedURL.standardizedFileURL.pathComponents
+        guard outputComponents.starts(with: rootComponents) else {
+            throw CocoaError(.fileReadCorruptFile, userInfo: [
+                NSFilePathErrorKey: stagedURL.path,
+                NSLocalizedDescriptionKey: "The extraction reported an output outside its staging directory.",
+            ])
+        }
+        return outputComponents.dropFirst(rootComponents.count).reduce(finalURL) {
+            $0.appendingPathComponent($1)
+        }
+    }
+
     @discardableResult
     func moveSidecarItemToPublishRoot(named itemName: String) throws -> Bool {
         let sourceURL = sidecarURL.appendingPathComponent(itemName, isDirectory: false)
@@ -271,6 +285,12 @@ struct FileManagerPreparedExtraction: @unchecked Sendable {
     var archiveOperationLease: FileManagerArchiveOperationGate.Lease?
 
     nonisolated func perform(session: SZOperationSession?) throws {
+        _ = try perform(session: session, collectOutputURLs: false)
+    }
+
+    nonisolated func perform(session: SZOperationSession?,
+                            collectOutputURLs: Bool) throws -> [URL]
+    {
         if materializeNewDestination,
            settings.pathMode != .absolutePaths,
            let materialization = try FileManagerExtractionMaterialization.prepareNewDestination(
@@ -280,24 +300,41 @@ struct FileManagerPreparedExtraction: @unchecked Sendable {
         {
             try materialization.createPublishRootDirectoryIfNeeded()
             var extractionError: Error?
+            var outputURLs: [URL] = []
             do {
-                try archive.extractEntries(entryIndices,
-                                           toPath: materialization.publishRootURL.path,
-                                           settings: settings,
-                                           session: session)
+                outputURLs = try extractEntries(to: materialization.publishRootURL,
+                                                session: session,
+                                                collectOutputURLs: collectOutputURLs)
+                    .map { try materialization.publishedURL(for: $0) }
             } catch {
                 extractionError = error
             }
             try materialization.finish(operationError: extractionError)
-            return
+            return outputURLs
         }
 
         // Absolute-path extraction and existing destinations cannot be represented as a single
         // publish root, so they keep the original direct extraction behavior.
+        return try extractEntries(to: destinationURL,
+                                  session: session,
+                                  collectOutputURLs: collectOutputURLs)
+    }
+
+    private nonisolated func extractEntries(to outputDirectory: URL,
+                                            session: SZOperationSession?,
+                                            collectOutputURLs: Bool) throws -> [URL]
+    {
+        if collectOutputURLs {
+            return try archive.extractEntriesWithOutputURLs(entryIndices,
+                                                            toPath: outputDirectory.path,
+                                                            settings: settings,
+                                                            session: session)
+        }
         try archive.extractEntries(entryIndices,
-                                   toPath: destinationURL.path,
+                                   toPath: outputDirectory.path,
                                    settings: settings,
                                    session: session)
+        return []
     }
 }
 

--- a/ShichiZip/FileManager/Pane/FileManagerPaneController.swift
+++ b/ShichiZip/FileManager/Pane/FileManagerPaneController.swift
@@ -2072,7 +2072,8 @@ class FileManagerPaneController: NSViewController, NSTableViewDataSource, NSTabl
                               cleanupDirectory: URL? = nil,
                               parentWindow: NSWindow? = nil,
                               requiresConfirmation: Bool = false,
-                              operationTitle: String? = nil)
+                              operationTitle: String? = nil,
+                              onSuccess: (@MainActor () -> Void)? = nil)
     {
         transferCoordinator.beginArchiveTransfer(urls,
                                                  to: target,
@@ -2082,7 +2083,8 @@ class FileManagerPaneController: NSViewController, NSTableViewDataSource, NSTabl
                                                  cleanupDirectory: cleanupDirectory,
                                                  parentWindow: parentWindow,
                                                  requiresConfirmation: requiresConfirmation,
-                                                 operationTitle: operationTitle)
+                                                 operationTitle: operationTitle,
+                                                 onSuccess: onSuccess)
     }
 
     func beginConfirmedArchiveTransfer(_ urls: [URL],

--- a/ShichiZip/FileManager/Transfer/FileManagerTransferSupport.swift
+++ b/ShichiZip/FileManager/Transfer/FileManagerTransferSupport.swift
@@ -1446,6 +1446,7 @@ final class FileOperationDestinationPrompt {
     private let defaultPath: String
     private let infoText: String
     private let validateDestination: (FileOperationDestinationTarget) -> Bool
+    private(set) var shouldRevealAfterTransfer = false
 
     init(move: Bool,
          sourcePane: FileManagerPaneController,
@@ -1495,7 +1496,13 @@ final class FileOperationDestinationPrompt {
         inputRow.spacing = 8
         inputRow.distribution = .fill
 
-        let stack = NSStackView(views: [label, inputRow])
+        let revealAfterTransferCheckbox = NSButton(checkboxWithTitle: SZL10n.string("app.fileManager.revealAfterTransfer"),
+                                                   target: nil,
+                                                   action: nil)
+        revealAfterTransferCheckbox.state = SZSettings.revealAfterTransfer ? .on : .off
+        revealAfterTransferCheckbox.setAccessibilityIdentifier("fileOperation.revealInFinder")
+
+        let stack = NSStackView(views: [label, inputRow, revealAfterTransferCheckbox])
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = 6
@@ -1535,6 +1542,8 @@ final class FileOperationDestinationPrompt {
                 guard validateDestination(destinationTarget) else {
                     return false
                 }
+                self.shouldRevealAfterTransfer = revealAfterTransferCheckbox.state == .on
+                SZSettings.revealAfterTransfer = self.shouldRevealAfterTransfer
                 resolvedDestinationTarget = destinationTarget
                 return true
             } catch {

--- a/ShichiZip/FileManager/Transfer/FileManagerTransferSupport.swift
+++ b/ShichiZip/FileManager/Transfer/FileManagerTransferSupport.swift
@@ -826,7 +826,8 @@ final class FileManagerPaneTransferCoordinator {
                               cleanupDirectory: URL? = nil,
                               parentWindow: NSWindow? = nil,
                               requiresConfirmation: Bool = false,
-                              operationTitle: String? = nil) -> Bool
+                              operationTitle: String? = nil,
+                              onSuccess: (@MainActor () -> Void)? = nil) -> Bool
     {
         guard !urls.isEmpty else {
             Self.removeCleanupDirectory(cleanupDirectory)
@@ -850,7 +851,8 @@ final class FileManagerPaneTransferCoordinator {
                                     cleanupDirectory: cleanupDirectory,
                                     parentWindow: parentWindow,
                                     requiresConfirmation: requiresConfirmation,
-                                    operationTitle: operationTitle)
+                                    operationTitle: operationTitle,
+                                    onSuccess: onSuccess)
     }
 
     @discardableResult
@@ -862,7 +864,8 @@ final class FileManagerPaneTransferCoordinator {
                               cleanupDirectory: URL? = nil,
                               parentWindow: NSWindow? = nil,
                               requiresConfirmation: Bool = false,
-                              operationTitle: String? = nil) -> Bool
+                              operationTitle: String? = nil,
+                              onSuccess: (@MainActor () -> Void)? = nil) -> Bool
     {
         guard !urls.isEmpty else {
             Self.removeCleanupDirectory(cleanupDirectory)
@@ -885,7 +888,8 @@ final class FileManagerPaneTransferCoordinator {
                                         sourceHost: sourceHost,
                                         host: host,
                                         cleanupDirectory: cleanupDirectory,
-                                        operationTitle: operationTitle)
+                                        operationTitle: operationTitle,
+                                        onSuccess: onSuccess)
             return true
         }
 
@@ -896,7 +900,8 @@ final class FileManagerPaneTransferCoordinator {
                                         sourceHost: sourceHost,
                                         host: host,
                                         cleanupDirectory: cleanupDirectory,
-                                        operationTitle: operationTitle)
+                                        operationTitle: operationTitle,
+                                        onSuccess: onSuccess)
             return true
         }
 
@@ -928,7 +933,8 @@ final class FileManagerPaneTransferCoordinator {
                                         sourceHost: sourceHost,
                                         host: host,
                                         cleanupDirectory: cleanupDirectory,
-                                        operationTitle: operationTitle)
+                                        operationTitle: operationTitle,
+                                        onSuccess: onSuccess)
         }
 
         return true
@@ -1072,7 +1078,8 @@ final class FileManagerPaneTransferCoordinator {
                                              sourceHost: (any FileManagerPaneTransferSourceHost)?,
                                              host: any FileManagerPaneTransferHost,
                                              cleanupDirectory: URL? = nil,
-                                             operationTitle: String? = nil)
+                                             operationTitle: String? = nil,
+                                             onSuccess: (@MainActor () -> Void)? = nil)
     {
         let defaultOperationTitle = operation == .move ? SZL10n.string("fileop.moving") : SZL10n.string("fileop.copying")
         let resolvedOperationTitle = operationTitle ?? defaultOperationTitle
@@ -1120,6 +1127,9 @@ final class FileManagerPaneTransferCoordinator {
                 }
                 if let committedError = outcome.committedError {
                     host.transferShowError(committedError)
+                }
+                if case .completed = outcome {
+                    onSuccess?()
                 }
             } catch {
                 host.transferShowError(error)
@@ -1359,6 +1369,7 @@ enum FileOperationArchiveDestinationTransfer {
                         candidatePanes: [FileManagerPaneController],
                         hasConflictingOpenNestedArchive: Bool,
                         parentWindow: NSWindow?,
+                        onSuccess: (@MainActor () -> Void)? = nil,
                         showError: @escaping @MainActor (Error) -> Void)
     {
         let operation: NSDragOperation = move ? .move : .copy
@@ -1386,7 +1397,8 @@ enum FileOperationArchiveDestinationTransfer {
                                       operation: operation,
                                       sourcePane: sourcePane,
                                       parentWindow: parentWindow,
-                                      requiresConfirmation: false)
+                                      requiresConfirmation: false,
+                                      onSuccess: onSuccess)
             return
         }
 
@@ -1433,6 +1445,9 @@ enum FileOperationArchiveDestinationTransfer {
                 }
                 if let committedError = outcome.committedError {
                     showError(committedError)
+                }
+                if case .completed = outcome {
+                    onSuccess?()
                 }
             } catch {
                 showError(error)

--- a/ShichiZip/FileManager/Transfer/FileManagerTransferSupport.swift
+++ b/ShichiZip/FileManager/Transfer/FileManagerTransferSupport.swift
@@ -1354,7 +1354,33 @@ enum FileOperationTransferReveal {
             NSWorkspace.shared.selectFile(destinationDirectory.path,
                                           inFileViewerRootedAtPath: destinationDirectory.deletingLastPathComponent().path)
         } else {
-            NSWorkspace.shared.activateFileViewerSelecting(itemURLs)
+            reveal(outputURLs: itemURLs, in: destinationDirectory)
+        }
+    }
+
+    static func reveal(outputURLs: [URL], in destinationDirectory: URL) {
+        let urls = itemURLs(for: outputURLs, in: destinationDirectory)
+        if !urls.isEmpty {
+            NSWorkspace.shared.activateFileViewerSelecting(urls)
+        }
+    }
+
+    nonisolated static func itemURLs(for outputURLs: [URL], in destinationDirectory: URL) -> [URL] {
+        let directory = destinationDirectory.standardizedFileURL
+        let rootComponents = directory.pathComponents
+        var seenPaths: Set<String> = []
+        return outputURLs.compactMap { outputURL in
+            let url = outputURL.standardizedFileURL
+            let components = url.pathComponents
+            let itemURL: URL
+            if components.starts(with: rootComponents),
+               components.count > rootComponents.count
+            {
+                itemURL = directory.appendingPathComponent(components[rootComponents.count])
+            } else {
+                itemURL = url
+            }
+            return seenPaths.insert(itemURL.path).inserted ? itemURL : nil
         }
     }
 }

--- a/ShichiZip/FileManager/Transfer/FileManagerTransferSupport.swift
+++ b/ShichiZip/FileManager/Transfer/FileManagerTransferSupport.swift
@@ -1334,6 +1334,22 @@ enum FileOperationFileSystemTransfer {
 }
 
 @MainActor
+enum FileOperationTransferReveal {
+    static func reveal(itemNames: [String], in destinationDirectory: URL) {
+        let itemURLs = itemNames.map {
+            destinationDirectory.appendingPathComponent($0, isDirectory: false)
+        }.filter { FileManager.default.fileExists(atPath: $0.path) }
+
+        if itemURLs.isEmpty {
+            NSWorkspace.shared.selectFile(destinationDirectory.path,
+                                          inFileViewerRootedAtPath: destinationDirectory.deletingLastPathComponent().path)
+        } else {
+            NSWorkspace.shared.activateFileViewerSelecting(itemURLs)
+        }
+    }
+}
+
+@MainActor
 enum FileOperationArchiveDestinationTransfer {
     static func perform(_ sourceURLs: [URL],
                         from sourcePane: FileManagerPaneController,

--- a/ShichiZip/FileManager/Window/FileManagerWindowCommandSupport.swift
+++ b/ShichiZip/FileManager/Window/FileManagerWindowCommandSupport.swift
@@ -108,12 +108,15 @@ enum FileManagerArchiveCommandSupport {
                     postProcessError = error
                 }
                 refreshPaneDisplayingDirectory(extractResult.destinationURL)
+                if extractResult.revealAfterExtractInFileManager {
+                    NSWorkspace.shared.selectFile(extractResult.destinationURL.path,
+                                                  inFileViewerRootedAtPath: extractResult.destinationURL.deletingLastPathComponent().path)
+                }
                 if postProcessResult.movedSourceArchiveToTrash,
                    let sourceArchiveURL
                 {
                     refreshPaneDisplayingDirectory(sourceArchiveURL.deletingLastPathComponent())
                 }
-                NSWorkspace.shared.open(extractResult.destinationURL)
                 if let postProcessError {
                     showError(postProcessError)
                 }
@@ -184,6 +187,10 @@ enum FileManagerArchiveCommandSupport {
                 try await copyPreparedArchiveItems(prepared,
                                                    parentWindow: parentWindow)
                 refreshPaneDisplayingDirectory(destinationURL)
+                if prompt.shouldRevealAfterTransfer {
+                    revealCopiedArchiveItems(snapshot: snapshot,
+                                             destinationURL: destinationURL)
+                }
             } catch {
                 showError(error)
             }
@@ -191,6 +198,20 @@ enum FileManagerArchiveCommandSupport {
             szPresentMessage(title: SZL10n.string("app.fileManager.operationNotAvailable"),
                              message: "Copying items from an open archive directly into another archive is not implemented yet.",
                              for: parentWindow)
+        }
+    }
+
+    private static func revealCopiedArchiveItems(snapshot: FileManagerPaneSnapshot,
+                                                 destinationURL: URL)
+    {
+        let itemURLs = snapshot.selection.displayedNames.map {
+            destinationURL.appendingPathComponent($0, isDirectory: false)
+        }.filter { FileManager.default.fileExists(atPath: $0.path) }
+        if itemURLs.isEmpty {
+            NSWorkspace.shared.selectFile(destinationURL.path,
+                                          inFileViewerRootedAtPath: destinationURL.deletingLastPathComponent().path)
+        } else {
+            NSWorkspace.shared.activateFileViewerSelecting(itemURLs)
         }
     }
 

--- a/ShichiZip/FileManager/Window/FileManagerWindowCommandSupport.swift
+++ b/ShichiZip/FileManager/Window/FileManagerWindowCommandSupport.swift
@@ -184,11 +184,12 @@ enum FileManagerArchiveCommandSupport {
             do {
                 let prepared = try activePane.prepareExtraction(to: destinationURL,
                                                                 overwriteMode: .ask)
-                try await copyPreparedArchiveItems(prepared,
-                                                   parentWindow: parentWindow)
+                let outputURLs = try await copyPreparedArchiveItems(prepared,
+                                                                    parentWindow: parentWindow,
+                                                                    collectOutputURLs: prompt.shouldRevealAfterTransfer)
                 refreshPaneDisplayingDirectory(destinationURL)
                 if prompt.shouldRevealAfterTransfer {
-                    FileOperationTransferReveal.reveal(itemNames: snapshot.selection.displayedNames,
+                    FileOperationTransferReveal.reveal(outputURLs: outputURLs,
                                                        in: destinationURL)
                 }
             } catch {
@@ -291,12 +292,13 @@ enum FileManagerArchiveCommandSupport {
     }
 
     private static func copyPreparedArchiveItems(_ prepared: FileManagerPreparedExtraction,
-                                                 parentWindow: NSWindow) async throws
+                                                 parentWindow: NSWindow,
+                                                 collectOutputURLs: Bool) async throws -> [URL]
     {
         try await ArchiveOperationRunner.run(operationTitle: SZL10n.string("fileop.copying"),
                                              parentWindow: parentWindow)
         { session in
-            try prepared.perform(session: session)
+            try prepared.perform(session: session, collectOutputURLs: collectOutputURLs)
         }
     }
 

--- a/ShichiZip/FileManager/Window/FileManagerWindowCommandSupport.swift
+++ b/ShichiZip/FileManager/Window/FileManagerWindowCommandSupport.swift
@@ -188,8 +188,8 @@ enum FileManagerArchiveCommandSupport {
                                                    parentWindow: parentWindow)
                 refreshPaneDisplayingDirectory(destinationURL)
                 if prompt.shouldRevealAfterTransfer {
-                    revealCopiedArchiveItems(snapshot: snapshot,
-                                             destinationURL: destinationURL)
+                    FileOperationTransferReveal.reveal(itemNames: snapshot.selection.displayedNames,
+                                                       in: destinationURL)
                 }
             } catch {
                 showError(error)
@@ -198,20 +198,6 @@ enum FileManagerArchiveCommandSupport {
             szPresentMessage(title: SZL10n.string("app.fileManager.operationNotAvailable"),
                              message: "Copying items from an open archive directly into another archive is not implemented yet.",
                              for: parentWindow)
-        }
-    }
-
-    private static func revealCopiedArchiveItems(snapshot: FileManagerPaneSnapshot,
-                                                 destinationURL: URL)
-    {
-        let itemURLs = snapshot.selection.displayedNames.map {
-            destinationURL.appendingPathComponent($0, isDirectory: false)
-        }.filter { FileManager.default.fileExists(atPath: $0.path) }
-        if itemURLs.isEmpty {
-            NSWorkspace.shared.selectFile(destinationURL.path,
-                                          inFileViewerRootedAtPath: destinationURL.deletingLastPathComponent().path)
-        } else {
-            NSWorkspace.shared.activateFileViewerSelecting(itemURLs)
         }
     }
 

--- a/ShichiZip/FileManager/Window/FileManagerWindowController.swift
+++ b/ShichiZip/FileManager/Window/FileManagerWindowController.swift
@@ -793,9 +793,10 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
             }
 
             guard snapshot.capabilities.canCopySelection else { return }
-            guard let unresolvedDestinationTarget = await promptForFileOperationDestination(forMove: false,
-                                                                                            sourcePane: pane)
+            guard let destinationSelection = await promptForFileOperationDestination(forMove: false,
+                                                                                      sourcePane: pane)
             else { return }
+            let unresolvedDestinationTarget = destinationSelection.target
 
             let destinationTarget: FileOperationDestinationTarget
             do {
@@ -817,6 +818,17 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                         try prepared.perform(session: session)
                     }
                     refreshPaneDisplayingDirectory(destURL)
+                    if destinationSelection.shouldRevealAfterTransfer {
+                        let itemURLs = snapshot.selection.displayedNames.map {
+                            destURL.appendingPathComponent($0, isDirectory: false)
+                        }.filter { FileManager.default.fileExists(atPath: $0.path) }
+                        if itemURLs.isEmpty {
+                            NSWorkspace.shared.selectFile(destURL.path,
+                                                          inFileViewerRootedAtPath: destURL.deletingLastPathComponent().path)
+                        } else {
+                            NSWorkspace.shared.activateFileViewerSelecting(itemURLs)
+                        }
+                    }
                 } catch {
                     showErrorAlert(error)
                 }
@@ -829,9 +841,10 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
         let sourceURLs = snapshot.selection.fileURLs
         guard !sourceURLs.isEmpty else { return }
 
-        guard let destinationTarget = await promptForFileOperationDestination(forMove: move,
-                                                                              sourcePane: pane)
+        guard let destinationSelection = await promptForFileOperationDestination(forMove: move,
+                                                                                 sourcePane: pane)
         else { return }
+        let destinationTarget = destinationSelection.target
         guard validateTransferDestination(destinationTarget,
                                           sourceURLs: sourceURLs,
                                           move: move,
@@ -984,7 +997,8 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
     }
 
     private func promptForFileOperationDestination(forMove move: Bool,
-                                                   sourcePane: FileManagerPaneController) async -> FileOperationDestinationTarget?
+                                                   sourcePane: FileManagerPaneController) async -> (target: FileOperationDestinationTarget,
+                                                                                                   shouldRevealAfterTransfer: Bool)?
     {
         let sourceSnapshot = sourcePane.snapshot
         let defaultPath = suggestedDestinationPath(for: sourcePane)
@@ -1002,7 +1016,11 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                                                presentingIn: nil)
         }
 
-        return await prompt.run(for: window)
+        guard let target = await prompt.run(for: window) else {
+            return nil
+        }
+        return (target: target,
+                shouldRevealAfterTransfer: prompt.shouldRevealAfterTransfer)
     }
 
     private func validateTransferDestination(_ destinationTarget: FileOperationDestinationTarget,

--- a/ShichiZip/FileManager/Window/FileManagerWindowController.swift
+++ b/ShichiZip/FileManager/Window/FileManagerWindowController.swift
@@ -819,15 +819,8 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                     }
                     refreshPaneDisplayingDirectory(destURL)
                     if destinationSelection.shouldRevealAfterTransfer {
-                        let itemURLs = snapshot.selection.displayedNames.map {
-                            destURL.appendingPathComponent($0, isDirectory: false)
-                        }.filter { FileManager.default.fileExists(atPath: $0.path) }
-                        if itemURLs.isEmpty {
-                            NSWorkspace.shared.selectFile(destURL.path,
-                                                          inFileViewerRootedAtPath: destURL.deletingLastPathComponent().path)
-                        } else {
-                            NSWorkspace.shared.activateFileViewerSelecting(itemURLs)
-                        }
+                        FileOperationTransferReveal.reveal(itemNames: snapshot.selection.displayedNames,
+                                                           in: destURL)
                     }
                 } catch {
                     showErrorAlert(error)
@@ -879,6 +872,10 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                                                                 to: destURL,
                                                                 operation: dragOperation,
                                                                 session: session)
+                }
+                if destinationSelection.shouldRevealAfterTransfer {
+                    FileOperationTransferReveal.reveal(itemNames: sourceURLs.map(\.lastPathComponent),
+                                                       in: destURL)
                 }
             } catch {
                 showErrorAlert(error)

--- a/ShichiZip/FileManager/Window/FileManagerWindowController.swift
+++ b/ShichiZip/FileManager/Window/FileManagerWindowController.swift
@@ -812,14 +812,15 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                 do {
                     let prepared = try pane.prepareSelectedItemExtraction(to: destURL,
                                                                           overwriteMode: .ask)
-                    try await ArchiveOperationRunner.run(operationTitle: SZL10n.string("fileop.copying"),
-                                                         parentWindow: parentWindow)
+                    let outputURLs = try await ArchiveOperationRunner.run(operationTitle: SZL10n.string("fileop.copying"),
+                                                                          parentWindow: parentWindow)
                     { session in
-                        try prepared.perform(session: session)
+                        try prepared.perform(session: session,
+                                             collectOutputURLs: destinationSelection.shouldRevealAfterTransfer)
                     }
                     refreshPaneDisplayingDirectory(destURL)
                     if destinationSelection.shouldRevealAfterTransfer {
-                        FileOperationTransferReveal.reveal(itemNames: snapshot.selection.displayedNames,
+                        FileOperationTransferReveal.reveal(outputURLs: outputURLs,
                                                            in: destURL)
                     }
                 } catch {

--- a/ShichiZip/FileManager/Window/FileManagerWindowController.swift
+++ b/ShichiZip/FileManager/Window/FileManagerWindowController.swift
@@ -885,7 +885,8 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                                               from: pane,
                                               toArchiveURL: archiveURL,
                                               subdir: subdir,
-                                              move: move)
+                                              move: move,
+                                              shouldRevealAfterTransfer: destinationSelection.shouldRevealAfterTransfer)
         }
     }
 
@@ -1041,7 +1042,8 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                                                    from sourcePane: FileManagerPaneController,
                                                    toArchiveURL archiveURL: URL,
                                                    subdir: String,
-                                                   move: Bool)
+                                                   move: Bool,
+                                                   shouldRevealAfterTransfer: Bool)
     {
         let hasConflictingOpenNestedArchive =
             FileManagerNestedArchiveConflictDetector.hasConflictingOpenInstance(
@@ -1055,7 +1057,12 @@ class FileManagerWindowController: NSWindowController, NSWindowDelegate, NSUserI
                                                         move: move,
                                                         candidatePanes: archiveCoordinationPaneControllers,
                                                         hasConflictingOpenNestedArchive: hasConflictingOpenNestedArchive,
-                                                        parentWindow: window)
+                                                        parentWindow: window,
+                                                        onSuccess: {
+                                                            if shouldRevealAfterTransfer {
+                                                                NSWorkspace.shared.activateFileViewerSelecting([archiveURL])
+                                                            }
+                                                        })
         { [weak self] error in
             self?.showErrorAlert(error)
         }

--- a/ShichiZip/Resources/Localization/en.lproj/App.strings
+++ b/ShichiZip/Resources/Localization/en.lproj/App.strings
@@ -104,6 +104,8 @@
 "app.fileManager.error.unableToCreate" = "Unable to create \"%@\".";
 "app.fileManager.fileManager" = "File Manager";
 "app.fileManager.operationNotAvailable" = "Operation Not Available";
+"app.fileManager.revealAfterExtract" = "Reveal extracted items in Finder when done";
+"app.fileManager.revealAfterTransfer" = "Reveal transferred items in Finder when done";
 "app.fileManager.quickLook.cannotPreview" = "The current selection cannot be previewed.";
 "app.fileManager.quickLook.cannotPreviewArchive" = "The current archive selection cannot be previewed.";
 "app.fileManager.quickLook.combinedSizeLimit" = "Quick Look previews from archives are limited to %@ for the current selection. The selected files total %@.";

--- a/ShichiZip/Resources/Localization/zh-Hans.lproj/App.strings
+++ b/ShichiZip/Resources/Localization/zh-Hans.lproj/App.strings
@@ -104,6 +104,8 @@
 "app.fileManager.error.unableToCreate" = "无法创建「%@」。";
 "app.fileManager.fileManager" = "文件管理器";
 "app.fileManager.operationNotAvailable" = "操作不可用";
+"app.fileManager.revealAfterExtract" = "完成后在 Finder 中显示解压项目";
+"app.fileManager.revealAfterTransfer" = "完成后在 Finder 中显示传输项目";
 "app.fileManager.quickLook.cannotPreview" = "当前选择无法预览。";
 "app.fileManager.quickLook.cannotPreviewArchive" = "当前压缩包选择无法预览。";
 "app.fileManager.quickLook.combinedSizeLimit" = "当前选择的快速查看预览限制为 %@，已选文件合计 %@。";

--- a/ShichiZip/Resources/Localization/zh-Hant.lproj/App.strings
+++ b/ShichiZip/Resources/Localization/zh-Hant.lproj/App.strings
@@ -104,6 +104,8 @@
 "app.fileManager.error.unableToCreate" = "無法建立「%@」。";
 "app.fileManager.fileManager" = "檔案管理器";
 "app.fileManager.operationNotAvailable" = "操作無法使用";
+"app.fileManager.revealAfterExtract" = "完成後在 Finder 中顯示解壓縮項目";
+"app.fileManager.revealAfterTransfer" = "完成後在 Finder 中顯示傳輸項目";
 "app.fileManager.quickLook.cannotPreview" = "目前選取項目無法預覽。";
 "app.fileManager.quickLook.cannotPreviewArchive" = "目前選取的壓縮檔項目無法預覽。";
 "app.fileManager.quickLook.combinedSizeLimit" = "目前選取項目的壓縮檔快速查看預覽限制為 %@。所選檔案總計 %@。";

--- a/ShichiZip/Utilities/SZSettings.swift
+++ b/ShichiZip/Utilities/SZSettings.swift
@@ -20,6 +20,8 @@ enum SZSettingsKey: String {
     case excludeMacResourceFilesByDefault = "ExcludeMacResourceFilesByDefault"
     case moveArchiveToTrashAfterExtraction = "MoveArchiveToTrashAfterExtraction"
     case inheritDownloadedFileQuarantine = "InheritDownloadedFileQuarantine"
+    case revealAfterExtractInFileManager = "RevealAfterExtractInFileManager"
+    case revealAfterTransfer = "RevealAfterTransfer"
     case memLimitEnabled = "MemLimitEnabled"
     case memLimitGB = "MemLimitGB"
 
@@ -77,6 +79,8 @@ enum LaunchOpenBrowseModifier: String {
 // MARK: - Settings Access
 
 enum SZSettings {
+    private static let legacyRevealAfterExtractKey = "RevealAfterExtract"
+
     private static var defaults: UserDefaults {
         SZSharedUserDefaults.defaults
     }
@@ -157,6 +161,34 @@ enum SZSettings {
                          forKey: ArchivePreviewPreferences.expansionDepthKey)
             postChange(forRawKey: ArchivePreviewPreferences.expansionDepthKey)
         }
+    }
+
+    static var revealAfterExtractInFileManager: Bool {
+        get { fileManagerRevealAfterExtract(defaults: defaults) }
+        set { set(newValue, for: .revealAfterExtractInFileManager) }
+    }
+
+    static var revealAfterTransfer: Bool {
+        get { fileManagerRevealAfterTransfer(defaults: defaults) }
+        set { set(newValue, for: .revealAfterTransfer) }
+    }
+
+    static func fileManagerRevealAfterExtract(defaults: UserDefaults) -> Bool {
+        let key = SZSettingsKey.revealAfterExtractInFileManager.rawValue
+        if defaults.object(forKey: key) == nil,
+           defaults.object(forKey: legacyRevealAfterExtractKey) != nil
+        {
+            let value = defaults.bool(forKey: legacyRevealAfterExtractKey)
+            defaults.set(value, forKey: key)
+            defaults.removeObject(forKey: legacyRevealAfterExtractKey)
+            return value
+        }
+        return defaults.object(forKey: key) == nil ? false : defaults.bool(forKey: key)
+    }
+
+    static func fileManagerRevealAfterTransfer(defaults: UserDefaults) -> Bool {
+        let key = SZSettingsKey.revealAfterTransfer.rawValue
+        return defaults.object(forKey: key) == nil ? false : defaults.bool(forKey: key)
     }
 
     // MARK: - Launch-open HUD

--- a/ShichiZip/Utilities/SZSettings.swift
+++ b/ShichiZip/Utilities/SZSettings.swift
@@ -79,10 +79,8 @@ enum LaunchOpenBrowseModifier: String {
 // MARK: - Settings Access
 
 enum SZSettings {
-    private static let legacyRevealAfterExtractKey = "RevealAfterExtract"
-
     private static var defaults: UserDefaults {
-        SZSharedUserDefaults.defaults
+        SZSettingsMigrations.defaults
     }
 
     private static func defaultBool(for key: SZSettingsKey) -> Bool {
@@ -164,31 +162,13 @@ enum SZSettings {
     }
 
     static var revealAfterExtractInFileManager: Bool {
-        get { fileManagerRevealAfterExtract(defaults: defaults) }
+        get { bool(.revealAfterExtractInFileManager) }
         set { set(newValue, for: .revealAfterExtractInFileManager) }
     }
 
     static var revealAfterTransfer: Bool {
-        get { fileManagerRevealAfterTransfer(defaults: defaults) }
+        get { bool(.revealAfterTransfer) }
         set { set(newValue, for: .revealAfterTransfer) }
-    }
-
-    static func fileManagerRevealAfterExtract(defaults: UserDefaults) -> Bool {
-        let key = SZSettingsKey.revealAfterExtractInFileManager.rawValue
-        if defaults.object(forKey: key) == nil,
-           defaults.object(forKey: legacyRevealAfterExtractKey) != nil
-        {
-            let value = defaults.bool(forKey: legacyRevealAfterExtractKey)
-            defaults.set(value, forKey: key)
-            defaults.removeObject(forKey: legacyRevealAfterExtractKey)
-            return value
-        }
-        return defaults.object(forKey: key) == nil ? false : defaults.bool(forKey: key)
-    }
-
-    static func fileManagerRevealAfterTransfer(defaults: UserDefaults) -> Bool {
-        let key = SZSettingsKey.revealAfterTransfer.rawValue
-        return defaults.object(forKey: key) == nil ? false : defaults.bool(forKey: key)
     }
 
     // MARK: - Launch-open HUD

--- a/ShichiZip/Utilities/SZSettingsMigrations.swift
+++ b/ShichiZip/Utilities/SZSettingsMigrations.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum SZSettingsMigrations {
+    private static let preferencesPrepared: Void = {
+        SZSharedUserDefaults.migrateStandardDefaultsIfNeeded()
+        run(defaults: SZSharedUserDefaults.defaults)
+    }()
+
+    static var defaults: UserDefaults {
+        preparePreferences()
+        return SZSharedUserDefaults.defaults
+    }
+
+    /// Runs once per launch, including when settings are accessed before app startup.
+    static func preparePreferences() {
+        _ = preferencesPrepared
+    }
+
+    /// Append adjacent migrations in order: A -> B, then B -> C.
+    /// Keep historical names as string literals here, not cases in SZSettingsKey.
+    /// Removing a link ends support for that upgrade path: if the current key cannot
+    /// be reached, it stays absent and SZSettings supplies its normal default.
+    static func run(defaults: UserDefaults) {
+        let migrator = SZPreferenceMigrator(defaults: defaults)
+        // Compatibility with the interim RevealAfterExtract key. The b60c261
+        // baseline has neither key, so its users get the new setting's default.
+        migrator.migrate(newKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue,
+                         oldKey: "RevealAfterExtract")
+    }
+}
+
+struct SZPreferenceMigrator {
+    let defaults: UserDefaults
+
+    /// Copies by default. A transform must return a UserDefaults-compatible value,
+    /// or nil to leave the old value untouched when conversion is not possible.
+    /// Existing destination values win; successful migrations remove the old key.
+    func migrate(newKey: String, oldKey: String, transform: (Any) -> Any? = { $0 }) {
+        guard newKey != oldKey,
+              let oldValue = defaults.object(forKey: oldKey) else {
+            return
+        }
+
+        if defaults.object(forKey: newKey) == nil {
+            guard let newValue = transform(oldValue) else { return }
+            defaults.set(newValue, forKey: newKey)
+        }
+        defaults.removeObject(forKey: oldKey)
+    }
+}

--- a/ShichiZip/Utilities/SZSettingsMigrations.swift
+++ b/ShichiZip/Utilities/SZSettingsMigrations.swift
@@ -22,9 +22,11 @@ enum SZSettingsMigrations {
     /// be reached, it stays absent and SZSettings supplies its normal default.
     static func run(defaults: UserDefaults) {
         let migrator = SZPreferenceMigrator(defaults: defaults)
-        // Compatibility with the interim RevealAfterExtract key. The b60c261
-        // baseline has neither key, so its users get the new setting's default.
-        migrator.migrate(newKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue,
+        migrator.migrate(newKeys: [
+            SZSettingsKey.revealAfterExtractInFileManager.rawValue,
+            SZSettingsKey.revealAfterTransfer.rawValue,
+            SZSettingsKey.launchOpenRevealAfterExtract.rawValue,
+        ],
                          oldKey: "RevealAfterExtract")
     }
 }
@@ -36,14 +38,22 @@ struct SZPreferenceMigrator {
     /// or nil to leave the old value untouched when conversion is not possible.
     /// Existing destination values win; successful migrations remove the old key.
     func migrate(newKey: String, oldKey: String, transform: (Any) -> Any? = { $0 }) {
-        guard newKey != oldKey,
+        migrate(newKeys: [newKey], oldKey: oldKey, transform: transform)
+    }
+
+    func migrate(newKeys: [String], oldKey: String, transform: (Any) -> Any? = { $0 }) {
+        guard !newKeys.isEmpty,
+              !newKeys.contains(oldKey),
               let oldValue = defaults.object(forKey: oldKey) else {
             return
         }
 
-        if defaults.object(forKey: newKey) == nil {
+        let missingKeys = newKeys.filter { defaults.object(forKey: $0) == nil }
+        if !missingKeys.isEmpty {
             guard let newValue = transform(oldValue) else { return }
-            defaults.set(newValue, forKey: newKey)
+            for key in missingKeys {
+                defaults.set(newValue, forKey: key)
+            }
         }
         defaults.removeObject(forKey: oldKey)
     }

--- a/ShichiZipTests/ExtractDialogResultBuilderTests.swift
+++ b/ShichiZipTests/ExtractDialogResultBuilderTests.swift
@@ -58,6 +58,17 @@ final class ExtractDialogResultBuilderTests: XCTestCase {
         }
     }
 
+    func testRevealAfterExtractInFileManagerChoiceIsReturned() throws {
+        let tempRoot = try makeTemporaryDirectory(named: "extract-dialog-reveal-in-finder")
+        let builder = ExtractDialogResultBuilder(baseDirectory: tempRoot)
+        var state = makeState(destinationPath: tempRoot.path)
+        state.revealAfterExtractInFileManager = true
+
+        let resolved = try builder.buildResult(from: state)
+
+        XCTAssertTrue(resolved.result.revealAfterExtractInFileManager)
+    }
+
     private func makeState(destinationPath: String,
                            splitDestination: Bool = false,
                            splitName: String = "Archive") -> ExtractDialogState
@@ -72,7 +83,8 @@ final class ExtractDialogResultBuilderTests: XCTestCase {
                            splitName: splitName,
                            showPassword: false,
                            moveArchiveToTrashAfterExtraction: false,
-                           inheritDownloadedFileQuarantine: false)
+                           inheritDownloadedFileQuarantine: false,
+                           revealAfterExtractInFileManager: false)
     }
 
     private func directoryExists(at url: URL) -> Bool {

--- a/ShichiZipTests/FileManagerArchiveExtractionTests.swift
+++ b/ShichiZipTests/FileManagerArchiveExtractionTests.swift
@@ -109,6 +109,192 @@ final class FileManagerArchiveExtractionTests: XCTestCase {
         XCTAssertTrue(prepared.settings.preserveNtSecurityInfo)
     }
 
+    func testPreparedExtractionReportsAutoRenamedFilesInsteadOfExistingFiles() throws {
+        for overwriteMode in [SZOverwriteMode.ask, .rename] {
+            let prepared = try makePreparedExtraction(names: ["report.txt"],
+                                                       overwriteMode: overwriteMode)
+            let existingURL = prepared.destinationURL.appendingPathComponent("report.txt")
+            try Data("existing".utf8).write(to: existingURL)
+            let session = SZOperationSession()
+            var askedToOverwrite = false
+            session.choiceRequestHandler = { _ in
+                askedToOverwrite = true
+                return 4
+            }
+
+            let outputs = try prepared.perform(session: session, collectOutputURLs: true)
+
+            XCTAssertEqual(outputs.count, 1)
+            let extractedURL = try XCTUnwrap(outputs.first)
+            XCTAssertNotEqual(extractedURL.path, existingURL.path)
+            XCTAssertEqual(try Data(contentsOf: extractedURL), Data("report.txt".utf8))
+            XCTAssertEqual(try Data(contentsOf: existingURL), Data("existing".utf8))
+            XCTAssertEqual(askedToOverwrite, overwriteMode == .ask)
+            XCTAssertEqual(FileOperationTransferReveal.itemURLs(for: outputs, in: prepared.destinationURL).map(\.path),
+                           [extractedURL.path])
+        }
+    }
+
+    func testPreparedExtractionReportsEveryOutputBeyondTheDialogPreviewLimit() throws {
+        let names = (1 ... 8).map { "item-\($0).txt" }
+        let prepared = try makePreparedExtraction(names: names)
+
+        let outputs = try prepared.perform(session: nil, collectOutputURLs: true)
+        let revealedItems = FileOperationTransferReveal.itemURLs(for: outputs, in: prepared.destinationURL)
+
+        XCTAssertEqual(outputs.count, names.count)
+        XCTAssertEqual(Set(outputs.map(\.lastPathComponent)), Set(names))
+        XCTAssertEqual(revealedItems.count, names.count)
+        XCTAssertEqual(Set(revealedItems.map(\.lastPathComponent)), Set(names))
+    }
+
+    func testPreparedExtractionOmitsSkippedFiles() throws {
+        let prepared = try makePreparedExtraction(names: ["existing.txt", "new.txt"],
+                                                   overwriteMode: .skip)
+        let existingURL = prepared.destinationURL.appendingPathComponent("existing.txt")
+        try Data("preserved".utf8).write(to: existingURL)
+
+        let outputs = try prepared.perform(session: nil, collectOutputURLs: true)
+
+        XCTAssertEqual(outputs.map(\.lastPathComponent), ["new.txt"])
+        XCTAssertEqual(try Data(contentsOf: existingURL), Data("preserved".utf8))
+    }
+
+    func testPreparedExtractionHasNothingToRevealWhenEveryFileIsSkipped() throws {
+        let prepared = try makePreparedExtraction(names: ["existing.txt"],
+                                                   overwriteMode: .skip)
+        try Data("preserved".utf8).write(to: prepared.destinationURL.appendingPathComponent("existing.txt"))
+
+        let outputs = try prepared.perform(session: nil, collectOutputURLs: true)
+
+        XCTAssertTrue(outputs.isEmpty)
+        XCTAssertTrue(FileOperationTransferReveal.itemURLs(for: outputs, in: prepared.destinationURL).isEmpty)
+    }
+
+    func testPreparedExtractionReturnsPublishedRatherThanStagingURLs() throws {
+        let names = ["first.txt", "second.txt"]
+        let prepared = try makePreparedExtraction(names: names, destinationExists: false)
+
+        let outputs = try prepared.perform(session: nil, collectOutputURLs: true)
+
+        XCTAssertEqual(Set(outputs.map(\.path)),
+                       Set(names.map { prepared.destinationURL.appendingPathComponent($0).path }))
+        for output in outputs {
+            XCTAssertEqual(try Data(contentsOf: output), Data(output.lastPathComponent.utf8))
+        }
+        let remainingItems = try FileManager.default.contentsOfDirectory(atPath: prepared.destinationURL.deletingLastPathComponent().path)
+        XCTAssertFalse(remainingItems.contains { $0.hasPrefix(FileManagerTemporaryDirectorySupport.extractionSidecarPrefix) })
+    }
+
+    func testPreparedExtractionCanSkipOutputCollection() throws {
+        let prepared = try makePreparedExtraction(names: ["payload.txt"], destinationExists: false)
+
+        let outputs = try prepared.perform(session: nil, collectOutputURLs: false)
+
+        XCTAssertTrue(outputs.isEmpty)
+        XCTAssertEqual(try Data(contentsOf: prepared.destinationURL.appendingPathComponent("payload.txt")),
+                       Data("payload.txt".utf8))
+    }
+
+    func testPreparedExtractionReportsEmptyDirectoriesAndSymbolicLinks() throws {
+        let root = try makeTemporaryDirectory(named: "extraction-output-links")
+        let source = root.appendingPathComponent("Source", isDirectory: true)
+        try FileManager.default.createDirectory(at: source.appendingPathComponent("empty", isDirectory: true),
+                                                withIntermediateDirectories: true)
+        try Data("payload".utf8).write(to: source.appendingPathComponent("file.txt"))
+        try FileManager.default.createSymbolicLink(atPath: source.appendingPathComponent("link").path,
+                                                   withDestinationPath: "file.txt")
+        try FileManager.default.createSymbolicLink(atPath: source.appendingPathComponent("dangling").path,
+                                                   withDestinationPath: "missing.txt")
+        let archiveURL = root.appendingPathComponent("source.zip")
+        try createZipFixture(at: archiveURL,
+                             currentDirectory: source,
+                             entryPaths: ["empty/", "file.txt", "link", "dangling"],
+                             preserveSymlinks: true)
+        let prepared = try makePreparedExtraction(archiveURL: archiveURL,
+                                                   destinationURL: root.appendingPathComponent("Destination", isDirectory: true))
+
+        let outputs = try prepared.perform(session: nil, collectOutputURLs: true)
+
+        XCTAssertEqual(Set(outputs.map(\.lastPathComponent)), ["empty", "file.txt", "link", "dangling"])
+        XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: prepared.destinationURL.appendingPathComponent("link").path),
+                       "file.txt")
+        XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: prepared.destinationURL.appendingPathComponent("dangling").path),
+                       "missing.txt")
+        XCTAssertEqual(FileOperationTransferReveal.itemURLs(for: outputs, in: prepared.destinationURL).count, 4)
+    }
+
+    func testOutputCollectionPropagatesExtractionFailure() throws {
+        let destination = try makeTemporaryDirectory(named: "extraction-output-failure")
+
+        XCTAssertThrowsError(try SZArchive().extractEntriesWithOutputURLs([0],
+                                                                          toPath: destination.path,
+                                                                          settings: SZExtractionSettings(),
+                                                                          session: nil))
+    }
+
+    func testRevealSelectionCollapsesNestedOutputsAndKeepsExternalPaths() {
+        let destination = URL(fileURLWithPath: "/tmp/output", isDirectory: true)
+        let external = URL(fileURLWithPath: "/tmp/output-other/file.txt")
+        let outputs = [
+            destination.appendingPathComponent("folder/first.txt"),
+            destination.appendingPathComponent("folder/second.txt"),
+            destination.appendingPathComponent("file.txt"),
+            destination.appendingPathComponent("file.txt"),
+            external,
+        ]
+
+        XCTAssertEqual(FileOperationTransferReveal.itemURLs(for: outputs, in: destination).map(\.path),
+                       [destination.appendingPathComponent("folder").path,
+                        destination.appendingPathComponent("file.txt").path,
+                        external.path])
+    }
+
+    private func makePreparedExtraction(names: [String],
+                                        destinationExists: Bool = true,
+                                        overwriteMode: SZOverwriteMode = .ask) throws -> FileManagerPreparedExtraction
+    {
+        let root = try makeTemporaryDirectory(named: "extraction-output-paths")
+        let source = root.appendingPathComponent("Source", isDirectory: true)
+        let destination = root.appendingPathComponent("Destination", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: false)
+        if destinationExists {
+            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: false)
+        }
+        let sourceURLs = names.map { source.appendingPathComponent($0) }
+        for sourceURL in sourceURLs {
+            try Data(sourceURL.lastPathComponent.utf8).write(to: sourceURL)
+        }
+        let archiveURL = root.appendingPathComponent("source.7z")
+        try createArchive(at: archiveURL, from: sourceURLs)
+        return try makePreparedExtraction(archiveURL: archiveURL,
+                                           destinationURL: destination,
+                                           overwriteMode: overwriteMode)
+    }
+
+    private func makePreparedExtraction(archiveURL: URL,
+                                        destinationURL: URL,
+                                        overwriteMode: SZOverwriteMode = .ask) throws -> FileManagerPreparedExtraction
+    {
+        let archive = SZArchive()
+        try archive.open(atPath: archiveURL.path, session: nil)
+        addTeardownBlock { archive.close() }
+        let entries = try FileManagerArchiveListing.items(from: archive, session: nil)
+        let context = FileManagerArchiveExtractionContext(archive: archive,
+                                                          allEntries: entries,
+                                                          currentSubdir: "",
+                                                          quarantineSourceArchivePath: nil)
+        return try XCTUnwrap(FileManagerArchiveExtraction.prepare(items: entries,
+                                                                   context: context,
+                                                                   destinationURL: destinationURL,
+                                                                   overwriteMode: overwriteMode,
+                                                                   pathMode: .currentPaths,
+                                                                   password: nil,
+                                                                   preserveNtSecurityInfo: false,
+                                                                   eliminateDuplicates: false,
+                                                                   inheritDownloadedFileQuarantine: false))
+    }
+
     private func makeContext(allEntries: [ArchiveItem] = [],
                              currentSubdir: String = "",
                              quarantineSourceArchivePath: String? = nil) -> FileManagerArchiveExtractionContext

--- a/ShichiZipTests/FileManagerPaneTransferCoordinatorTests.swift
+++ b/ShichiZipTests/FileManagerPaneTransferCoordinatorTests.swift
@@ -18,7 +18,8 @@ final class FileManagerPaneTransferCoordinatorTests: XCTestCase {
                                                         operation: .copy,
                                                         sourceHost: nil,
                                                         host: host,
-                                                        cleanupDirectory: cleanupDirectory)
+                                                        cleanupDirectory: cleanupDirectory,
+                                                        onSuccess: { XCTFail("An empty transfer must not report success.") })
 
         XCTAssertFalse(didBegin)
         XCTAssertFalse(FileManager.default.fileExists(atPath: cleanupDirectory.path))
@@ -39,12 +40,82 @@ final class FileManagerPaneTransferCoordinatorTests: XCTestCase {
                                                         operation: .copy,
                                                         sourceHost: nil,
                                                         host: host,
-                                                        cleanupDirectory: cleanupDirectory)
+                                                        cleanupDirectory: cleanupDirectory,
+                                                        onSuccess: { XCTFail("An unavailable target must not report success.") })
 
         XCTAssertFalse(didBegin)
         XCTAssertFalse(FileManager.default.fileExists(atPath: cleanupDirectory.path))
         XCTAssertEqual(host.requestedSubdir, "nested")
         XCTAssertEqual(host.readOnlyActions, [SZL10n.string("app.fileManager.action.addingFilesToArchive")])
+    }
+
+    func testArchiveTransferReportsSuccessAfterCopyAndMove() async throws {
+        for operation: NSDragOperation in [.copy, .move] {
+            let tempRoot = try makeTemporaryDirectory(named: "archive-transfer-success")
+            let initialDirectory = tempRoot.appendingPathComponent("nested", isDirectory: true)
+            let initialURL = initialDirectory.appendingPathComponent("initial.txt")
+            let sourceURL = tempRoot.appendingPathComponent("payload.txt")
+            let archiveURL = tempRoot.appendingPathComponent("destination.7z")
+            try FileManager.default.createDirectory(at: initialDirectory, withIntermediateDirectories: false)
+            try Data("initial".utf8).write(to: initialURL)
+            try Data("payload".utf8).write(to: sourceURL)
+            try createArchive(at: archiveURL, from: [initialDirectory])
+
+            let archive = SZArchive()
+            try archive.open(atPath: archiveURL.path, session: nil)
+            defer { archive.close() }
+
+            let host = TransferHostProbe()
+            host.archiveTarget = FileManagerPaneArchiveTransferTarget(archive: archive,
+                                                                      subdir: "nested",
+                                                                      archiveURL: archiveURL)
+            let completed = expectation(description: "Transfer completed")
+            host.onError = { error in
+                XCTFail("Transfer failed: \(error)")
+                completed.fulfill()
+            }
+            let coordinator = FileManagerPaneTransferCoordinator()
+            let didBegin = coordinator.beginArchiveTransfer([sourceURL],
+                                                            to: (archive: archive, subdir: "nested"),
+                                                            operation: operation,
+                                                            sourceHost: nil,
+                                                            host: host,
+                                                            onSuccess: {
+                                                                XCTAssertEqual(host.mutatedSelectionPaths, ["nested/payload.txt"])
+                                                                completed.fulfill()
+                                                            })
+
+            XCTAssertTrue(didBegin)
+            await fulfillment(of: [completed], timeout: 5)
+            XCTAssertTrue(host.errors.isEmpty)
+            XCTAssertTrue(archive.entries().contains { $0.path == "nested/payload.txt" })
+            XCTAssertEqual(FileManager.default.fileExists(atPath: sourceURL.path), operation != .move)
+        }
+    }
+
+    func testArchiveTransferDoesNotReportSuccessWhenUpdateFails() async throws {
+        let tempRoot = try makeTemporaryDirectory(named: "archive-transfer-failure")
+        let sourceURL = tempRoot.appendingPathComponent("payload.txt")
+        try Data("payload".utf8).write(to: sourceURL)
+        let archive = SZArchive()
+        let host = TransferHostProbe()
+        host.archiveTarget = FileManagerPaneArchiveTransferTarget(archive: archive,
+                                                                  subdir: "",
+                                                                  archiveURL: tempRoot.appendingPathComponent("closed.7z"))
+        let failed = expectation(description: "Transfer failed")
+        host.onError = { _ in failed.fulfill() }
+        let coordinator = FileManagerPaneTransferCoordinator()
+
+        XCTAssertTrue(coordinator.beginArchiveTransfer([sourceURL],
+                                                        to: (archive: archive, subdir: ""),
+                                                        operation: .copy,
+                                                        sourceHost: nil,
+                                                        host: host,
+                                                        onSuccess: { XCTFail("A failed transfer must not report success.") }))
+
+        await fulfillment(of: [failed], timeout: 5)
+        XCTAssertEqual(host.errors.count, 1)
+        XCTAssertTrue(host.mutatedSelectionPaths.isEmpty)
     }
 }
 
@@ -56,6 +127,11 @@ private final class TransferHostProbe: FileManagerPaneTransferHost {
 
     var requestedSubdir: String?
     var readOnlyActions: [String] = []
+    var archiveTarget: FileManagerPaneArchiveTransferTarget?
+    var mutatedSelectionPaths: [String] = []
+    var errors: [Error] = []
+    var onError: ((Error) -> Void)?
+    private let operationGate = FileManagerArchiveOperationGate()
 
     func transferRefresh() {}
 
@@ -71,24 +147,33 @@ private final class TransferHostProbe: FileManagerPaneTransferHost {
         nil
     }
 
-    func transferArchiveMutationTarget(for _: SZArchive, subdir: String) -> FileManagerPaneArchiveTransferTarget? {
+    func transferArchiveMutationTarget(for archive: SZArchive, subdir: String) -> FileManagerPaneArchiveTransferTarget? {
         requestedSubdir = subdir
-        return nil
+        guard let archiveTarget, archiveTarget.archive === archive else { return nil }
+        return archiveTarget
     }
 
-    func transferLeasedArchiveMutationTarget(for _: SZArchive, subdir: String) -> FileManagerLeasedArchiveMutationTarget? {
+    func transferLeasedArchiveMutationTarget(for archive: SZArchive, subdir: String) -> FileManagerLeasedArchiveMutationTarget? {
         requestedSubdir = subdir
-        return nil
+        guard archiveTarget?.archive === archive,
+              let lease = operationGate.acquireLease()
+        else { return nil }
+        return FileManagerLeasedArchiveMutationTarget(archive: archive, subdir: subdir, lease: lease)
     }
 
     func transferDidMutateArchive(targetSubdir _: String?,
-                                  selectingPaths _: [String],
+                                  selectingPaths paths: [String],
                                   reopenBeforeListing _: Bool)
-    {}
+    {
+        mutatedSelectionPaths = paths
+    }
 
     func transferShowReadOnlyArchiveMutationAlert(action: String) {
         readOnlyActions.append(action)
     }
 
-    func transferShowError(_: Error) {}
+    func transferShowError(_ error: Error) {
+        errors.append(error)
+        onError?(error)
+    }
 }

--- a/ShichiZipTests/SharedUserDefaultsTests.swift
+++ b/ShichiZipTests/SharedUserDefaultsTests.swift
@@ -42,6 +42,113 @@ final class SharedUserDefaultsTests: XCTestCase {
         XCTAssertNil(source.defaults.persistentDomain(forName: source.suiteName))
     }
 
+    func testSettingsMigrationPreservesBothBooleanValues() throws {
+        for value in [false, true] {
+            let defaults = try makeIsolatedDefaults().defaults
+            defaults.set(value, forKey: "RevealAfterExtract")
+
+            SZSettingsMigrations.run(defaults: defaults)
+
+            XCTAssertEqual(defaults.object(forKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue) as? Bool,
+                           value)
+            XCTAssertNil(defaults.object(forKey: "RevealAfterExtract"))
+        }
+    }
+
+    func testSettingsMigrationPreservesNewValueAndRemovesObsoleteKey() throws {
+        let defaults = try makeIsolatedDefaults().defaults
+        defaults.set(true, forKey: "RevealAfterExtract")
+        defaults.set(false, forKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue)
+
+        SZSettingsMigrations.run(defaults: defaults)
+        SZSettingsMigrations.run(defaults: defaults)
+
+        XCTAssertFalse(defaults.bool(forKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue))
+        XCTAssertNil(defaults.object(forKey: "RevealAfterExtract"))
+    }
+
+    func testSettingsMigrationDoesNotCreateValuesOnFreshInstall() throws {
+        let defaults = try makeIsolatedDefaults().defaults
+
+        SZSettingsMigrations.run(defaults: defaults)
+
+        XCTAssertNil(defaults.object(forKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue))
+    }
+
+    func testPreferenceMigrationTransformsAndChainsAcrossSkippedVersions() throws {
+        let defaults = try makeIsolatedDefaults().defaults
+        let migrator = SZPreferenceMigrator(defaults: defaults)
+        defaults.set("42", forKey: "Original")
+
+        migrator.migrate(newKey: "Intermediate", oldKey: "Original")
+        migrator.migrate(newKey: "Current", oldKey: "Intermediate") { value in
+            (value as? String).flatMap(Int.init)
+        }
+
+        XCTAssertEqual(defaults.integer(forKey: "Current"), 42)
+        XCTAssertNil(defaults.object(forKey: "Original"))
+        XCTAssertNil(defaults.object(forKey: "Intermediate"))
+
+        defaults.set(99, forKey: "Current")
+        migrator.migrate(newKey: "Current", oldKey: "Intermediate")
+        XCTAssertEqual(defaults.integer(forKey: "Current"), 99)
+    }
+
+    func testPreferenceMigrationKeepsSourceWhenConversionFails() throws {
+        let defaults = try makeIsolatedDefaults().defaults
+        let migrator = SZPreferenceMigrator(defaults: defaults)
+        defaults.set("invalid", forKey: "Old")
+
+        migrator.migrate(newKey: "New", oldKey: "Old") { value in
+            (value as? String).flatMap(Int.init)
+        }
+
+        XCTAssertEqual(defaults.string(forKey: "Old"), "invalid")
+        XCTAssertNil(defaults.object(forKey: "New"))
+    }
+
+    func testBrokenMigrationChainLeavesCurrentSettingAtDefault() throws {
+        let defaults = try makeIsolatedDefaults().defaults
+        defaults.set(true, forKey: "Original")
+
+        // The Original -> Intermediate migration has been removed.
+        SZPreferenceMigrator(defaults: defaults).migrate(newKey: "Current", oldKey: "Intermediate")
+
+        XCTAssertNil(defaults.object(forKey: "Current"))
+        XCTAssertFalse(defaults.bool(forKey: "Current"))
+    }
+
+    func testBrokenMigrationChainPreservesExistingCurrentValue() throws {
+        let defaults = try makeIsolatedDefaults().defaults
+        defaults.set(false, forKey: "Original")
+        defaults.set(true, forKey: "Current")
+
+        SZPreferenceMigrator(defaults: defaults).migrate(newKey: "Current", oldKey: "Intermediate")
+
+        XCTAssertTrue(defaults.bool(forKey: "Current"))
+    }
+
+    func testBaselineRevealPreferenceIsUnchanged() throws {
+        let defaults = try makeIsolatedDefaults().defaults
+        let baselineKey = SZSettingsKey.launchOpenRevealAfterExtract.rawValue
+        defaults.set(true, forKey: baselineKey)
+
+        SZSettingsMigrations.run(defaults: defaults)
+
+        XCTAssertTrue(defaults.bool(forKey: baselineKey))
+        XCTAssertNil(defaults.object(forKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue))
+        XCTAssertNil(defaults.object(forKey: SZSettingsKey.revealAfterTransfer.rawValue))
+    }
+
+    func testPreferenceMigrationIgnoresIdenticalKeys() throws {
+        let defaults = try makeIsolatedDefaults().defaults
+        defaults.set("keep", forKey: "Same")
+
+        SZPreferenceMigrator(defaults: defaults).migrate(newKey: "Same", oldKey: "Same")
+
+        XCTAssertEqual(defaults.string(forKey: "Same"), "keep")
+    }
+
     private func makeIsolatedDefaults() throws -> (suiteName: String, defaults: UserDefaults) {
         let suiteName = "SharedUserDefaultsTests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/ShichiZipTests/SharedUserDefaultsTests.swift
+++ b/ShichiZipTests/SharedUserDefaultsTests.swift
@@ -7,6 +7,12 @@ import Foundation
 import XCTest
 
 final class SharedUserDefaultsTests: XCTestCase {
+    private let revealPreferenceKeys: [SZSettingsKey] = [
+        .revealAfterExtractInFileManager,
+        .revealAfterTransfer,
+        .launchOpenRevealAfterExtract,
+    ]
+
     func testSharedDefaultsUsesConfiguredAppGroupWhenAvailable() throws {
         guard SZSharedUserDefaults.appGroupIdentifier != nil else {
             throw XCTSkip("App group identifier is not configured for this test host.")
@@ -49,22 +55,31 @@ final class SharedUserDefaultsTests: XCTestCase {
 
             SZSettingsMigrations.run(defaults: defaults)
 
-            XCTAssertEqual(defaults.object(forKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue) as? Bool,
-                           value)
+            for key in revealPreferenceKeys {
+                XCTAssertEqual(defaults.object(forKey: key.rawValue) as? Bool,
+                               value,
+                               key.rawValue)
+            }
             XCTAssertNil(defaults.object(forKey: "RevealAfterExtract"))
         }
     }
 
     func testSettingsMigrationPreservesNewValueAndRemovesObsoleteKey() throws {
-        let defaults = try makeIsolatedDefaults().defaults
-        defaults.set(true, forKey: "RevealAfterExtract")
-        defaults.set(false, forKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue)
+        for preservedKey in revealPreferenceKeys {
+            let defaults = try makeIsolatedDefaults().defaults
+            defaults.set(true, forKey: "RevealAfterExtract")
+            defaults.set(false, forKey: preservedKey.rawValue)
 
-        SZSettingsMigrations.run(defaults: defaults)
-        SZSettingsMigrations.run(defaults: defaults)
+            SZSettingsMigrations.run(defaults: defaults)
+            SZSettingsMigrations.run(defaults: defaults)
 
-        XCTAssertFalse(defaults.bool(forKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue))
-        XCTAssertNil(defaults.object(forKey: "RevealAfterExtract"))
+            for key in revealPreferenceKeys {
+                XCTAssertEqual(defaults.object(forKey: key.rawValue) as? Bool,
+                               key != preservedKey,
+                               key.rawValue)
+            }
+            XCTAssertNil(defaults.object(forKey: "RevealAfterExtract"))
+        }
     }
 
     func testSettingsMigrationDoesNotCreateValuesOnFreshInstall() throws {
@@ -72,7 +87,9 @@ final class SharedUserDefaultsTests: XCTestCase {
 
         SZSettingsMigrations.run(defaults: defaults)
 
-        XCTAssertNil(defaults.object(forKey: SZSettingsKey.revealAfterExtractInFileManager.rawValue))
+        for key in revealPreferenceKeys {
+            XCTAssertNil(defaults.object(forKey: key.rawValue))
+        }
     }
 
     func testPreferenceMigrationTransformsAndChainsAcrossSkippedVersions() throws {
@@ -105,6 +122,40 @@ final class SharedUserDefaultsTests: XCTestCase {
 
         XCTAssertEqual(defaults.string(forKey: "Old"), "invalid")
         XCTAssertNil(defaults.object(forKey: "New"))
+    }
+
+    func testPreferenceMigrationFansOutBeforeRemovingSource() throws {
+        let defaults = try makeIsolatedDefaults().defaults
+        defaults.set("42", forKey: "Old")
+        defaults.set(99, forKey: "Preserved")
+
+        SZPreferenceMigrator(defaults: defaults).migrate(newKeys: ["First", "Preserved", "Second"],
+                                                         oldKey: "Old")
+        { value in
+            (value as? String).flatMap(Int.init)
+        }
+
+        XCTAssertEqual(defaults.integer(forKey: "First"), 42)
+        XCTAssertEqual(defaults.integer(forKey: "Second"), 42)
+        XCTAssertEqual(defaults.integer(forKey: "Preserved"), 99)
+        XCTAssertNil(defaults.object(forKey: "Old"))
+    }
+
+    func testPreferenceMigrationPreservesAllValuesWhenFanOutConversionFails() throws {
+        let defaults = try makeIsolatedDefaults().defaults
+        defaults.set("invalid", forKey: "Old")
+        defaults.set(99, forKey: "Preserved")
+
+        SZPreferenceMigrator(defaults: defaults).migrate(newKeys: ["First", "Preserved", "Second"],
+                                                         oldKey: "Old")
+        { value in
+            (value as? String).flatMap(Int.init)
+        }
+
+        XCTAssertNil(defaults.object(forKey: "First"))
+        XCTAssertNil(defaults.object(forKey: "Second"))
+        XCTAssertEqual(defaults.integer(forKey: "Preserved"), 99)
+        XCTAssertEqual(defaults.string(forKey: "Old"), "invalid")
     }
 
     func testBrokenMigrationChainLeavesCurrentSettingAtDefault() throws {

--- a/vendor/7zip-26.02-0005-report-extracted-output-paths.patch
+++ b/vendor/7zip-26.02-0005-report-extracted-output-paths.patch
@@ -1,0 +1,32 @@
+diff --git a/CPP/7zip/UI/Common/ArchiveExtractCallback.h b/CPP/7zip/UI/Common/ArchiveExtractCallback.h
+--- a/CPP/7zip/UI/Common/ArchiveExtractCallback.h
++++ b/CPP/7zip/UI/Common/ArchiveExtractCallback.h
+@@ -494,6 +494,9 @@ public:
+   
+   FString DirPathPrefix_for_HashFiles;
+ 
++  // Optional caller-owned sink for output paths after overwrite/rename handling.
++  FStringVector *ExtractedPaths = NULL;
++
+   CArchiveExtractCallback();
+ 
+   void InitForMulti(bool multiArchives,
+diff --git a/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp b/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
+--- a/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
++++ b/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
+@@ -2774,6 +2774,15 @@ Z7_COM7F_IMF(CArchiveExtractCallback::SetOperationResult(Int32 opRes))
+   if (_needSetAttrib)
+     SetAttrib();
+   
++  if (ExtractedPaths && opRes == NArchive::NExtract::NOperationResult::kOK
++      && _extractMode && !_itemFailure && !_diskFilePath.IsEmpty())
++  {
++    bool isAnti = false;
++    RINOK(_arc->IsItem_Anti(_index, isAnti))
++    if (!isAnti)
++      ExtractedPaths->Add(_diskFilePath);
++  }
++
+   RINOK(_extractCallback2->SetOperationResult(opRes, BoolToInt(_encrypted)))
+   
+   return S_OK;

--- a/vendor/7zip-zstd-26.02-0005-report-extracted-output-paths.patch
+++ b/vendor/7zip-zstd-26.02-0005-report-extracted-output-paths.patch
@@ -1,0 +1,31 @@
+diff --git a/CPP/7zip/UI/Common/ArchiveExtractCallback.h b/CPP/7zip/UI/Common/ArchiveExtractCallback.h
+--- a/CPP/7zip/UI/Common/ArchiveExtractCallback.h
++++ b/CPP/7zip/UI/Common/ArchiveExtractCallback.h
+@@ -498,5 +498,8 @@ public:
+   FString DirPathPrefix_for_HashFiles;
+ 
++  // Optional caller-owned sink for output paths after overwrite/rename handling.
++  FStringVector *ExtractedPaths = NULL;
++
+   CArchiveExtractCallback();
+ 
+   void InitForMulti(bool multiArchives,
+diff --git a/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp b/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
+--- a/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
++++ b/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
+@@ -2776,6 +2776,15 @@ Z7_COM7F_IMF(CArchiveExtractCallback::SetOperationResult(Int32 opRes))
+   if (_needSetAttrib)
+     SetAttrib();
+   
++  if (ExtractedPaths && opRes == NArchive::NExtract::NOperationResult::kOK
++      && _extractMode && !_itemFailure && !_diskFilePath.IsEmpty())
++  {
++    bool isAnti = false;
++    RINOK(_arc->IsItem_Anti(_index, isAnti))
++    if (!isAnti)
++      ExtractedPaths->Add(_diskFilePath);
++  }
++
+   RINOK(_extractCallback2->SetOperationResult(opRes, BoolToInt(_encrypted)))
+   
+   return S_OK;


### PR DESCRIPTION
## Summary
Add independent Finder reveal controls for file manager and transfer dialogs. So there are reveal option in three dialog:
  - File Manager extraction dialog: optionally reveal the extracted destination in Finder.
  - Transfer destination dialog: optionally reveal transferred items in Finder.
  - Launch-open auto-extraction diglog: keep its reveal behavior as a separate Settings preference.

Each preference is persisted independently. On first access, the legacy `RevealAfterExtract` value is used to migrate `RevealAfterExtract ` behavior in launch open and set as default value of `revealAfterExtractInFileManager` and `revealAfterTransfer`.  

New localized labels are included for English, Simplified Chinese, and Traditional Chinese.

<img width="1100" height="820" alt="1Capture_2026-09-01_21 23 18@2x" src="https://github.com/user-attachments/assets/fda2531a-2867-4e97-a593-fe2f0f810f11" />

<img width="1100" height="820" alt="1Capture_2026-09-01_21 21 20@2x" src="https://github.com/user-attachments/assets/2d0f18b3-926a-46f2-94bf-724bdd7964c8" />
<img width="1100" height="820" alt="image" src="https://github.com/user-attachments/assets/f69866bc-b5d9-49b9-9f27-0b0bba4116bc" />

## WHY
Reopen the extracted folder is difficult . Eespecailly for nested destination .